### PR TITLE
feat: add dropdown element component

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -32,6 +32,7 @@ DropdownSelection.args = {
     position: 'bottom',
     children: [
         <DropdownElement
+            key="0"
             height={50}
             width={260}
             text={'Testnet Server'}
@@ -43,6 +44,7 @@ DropdownSelection.args = {
             onClick={() => alert('Testnet Server')}
         />,
         <DropdownElement
+            key="1"
             height={50}
             width={260}
             text={'Mainnet Server'}
@@ -54,6 +56,7 @@ DropdownSelection.args = {
             onClick={() => alert('Mainnet Server')}
         />,
         <DropdownElement
+            key="2"
             height={50}
             width={260}
             text={'Local Devchain Server'}
@@ -66,7 +69,7 @@ DropdownSelection.args = {
         />,
     ],
     parent: (
-        <Icon key="10" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
+        <Icon key="3" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
     ),
 };
 
@@ -75,6 +78,7 @@ DropdownSelectionUser.args = {
     position: 'bottom',
     children: [
         <DropdownElement
+            key="4"
             height={50}
             width={260}
             text={'Account Settings'}
@@ -86,6 +90,7 @@ DropdownSelectionUser.args = {
             onClick={() => alert('Account Settings')}
         />,
         <DropdownElement
+            key="5"
             height={50}
             width={260}
             text={'Support Page'}
@@ -97,6 +102,7 @@ DropdownSelectionUser.args = {
             onClick={() => alert('Support Page')}
         />,
         <DropdownElement
+            key="6"
             height={50}
             width={260}
             text={'Logout'}
@@ -110,6 +116,6 @@ DropdownSelectionUser.args = {
         />,
     ],
     parent: (
-        <Icon key="11" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
+        <Icon key="7" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
     ),
 };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,115 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import color from '../../styles/colors';
+import colors from '../../styles/colors';
+import Dropdown from '../Dropdown/Dropdown';
+import DropdownElement from '../DropdownElement/DropdownElement';
+import { Icon } from '../Icon';
+import { iconTypes } from '../Icon/collection';
+
+export default {
+    title: 'UI/Dropdown',
+    component: Dropdown,
+    argTypes: { onClick: { action: 'clicked' } },
+} as ComponentMeta<typeof Dropdown>;
+
+const Template: ComponentStory<typeof Dropdown> = (args) => (
+    <div
+        style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            margin: 0,
+            minHeight: '100vh',
+        }}
+    >
+        <Dropdown {...args} />
+    </div>
+);
+
+export const DropdownSelection = Template.bind({});
+DropdownSelection.args = {
+    position: 'bottom',
+    children: [
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Testnet Server'}
+            textSize={20}
+            icon={iconTypes.testnet}
+            iconSize={30}
+            backgroundColor={'transparent'}
+            textColor={colors.white}
+            onClick={() => alert('Testnet Server')}
+        />,
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Mainnet Server'}
+            textSize={20}
+            iconSize={30}
+            icon={iconTypes.network}
+            backgroundColor={'transparent'}
+            textColor={colors.white}
+            onClick={() => alert('Mainnet Server')}
+        />,
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Local Devchain Server'}
+            textSize={20}
+            iconSize={30}
+            backgroundColor={'transparent'}
+            icon={iconTypes.server}
+            textColor={colors.white}
+            onClick={() => alert('Local Devchain Server')}
+        />,
+    ],
+    parent: (
+        <Icon key="10" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
+    ),
+};
+
+export const DropdownSelectionUser = Template.bind({});
+DropdownSelectionUser.args = {
+    position: 'bottom',
+    children: [
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Account Settings'}
+            textSize={20}
+            icon={iconTypes.cog}
+            iconSize={30}
+            backgroundColor={'transparent'}
+            textColor={colors.white}
+            onClick={() => alert('Account Settings')}
+        />,
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Support Page'}
+            textSize={20}
+            iconSize={30}
+            icon={iconTypes.lifeRing}
+            backgroundColor={'transparent'}
+            textColor={colors.white}
+            onClick={() => alert('Support Page')}
+        />,
+        <DropdownElement
+            height={50}
+            width={260}
+            text={'Logout'}
+            textSize={20}
+            iconSize={30}
+            backgroundColor={'transparent'}
+            iconColor={colors.red}
+            icon={iconTypes.logOut}
+            textColor={colors.red}
+            onClick={() => alert('Logout')}
+        />,
+    ],
+    parent: (
+        <Icon key="11" svg={iconTypes.helpCircle} fill={color.grey} size={50} />
+    ),
+};

--- a/src/components/Dropdown/Dropdown.styles.tsx
+++ b/src/components/Dropdown/Dropdown.styles.tsx
@@ -1,0 +1,123 @@
+import styled, { css } from 'styled-components';
+import color from '../../styles/colors';
+import { DropdownProps, Position } from './types';
+
+const arrowSize = '10px';
+
+const borderRadius = '20px';
+
+const bottom = css<Pick<DropdownProps, 'move'>>`
+    background: ${color.blueDark};
+    bottom: -0.25rem;
+    left: 50%;
+    position: absolute;
+    transform: translateX(-50%) translateY(100%);
+    &:after {
+        position: absolute;
+        content: '';
+        bottom: 100%;
+        transform: translateX(${(p) => (p.move ? `${p.move}%` : '-50%')})
+            translateY(0%);
+        border: ${arrowSize} solid transparent;
+        border-bottom-color: ${color.blueDark};
+    }
+`;
+
+const DivArrowStyled = styled.div<Pick<DropdownProps, 'position' | 'move'>>`
+    ${(p) => (p.position ? getContainerStyleByPosition(p.position) : '')}
+`;
+
+const DivContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    width: max-content;
+`;
+
+const DivDropdownElementStyled = styled.div<Pick<DropdownProps, 'position'>>`
+    background: ${color.blueDark};
+    border-radius: ${borderRadius};
+    height: auto;
+    overflow: hidden;
+    position: absolute;
+    width: max-content;
+    ${(p) => getContainerStyleByPosition(p.position)}
+`;
+
+const ElementDiv = styled.div`
+    cursor: pointer;
+    height: auto;
+    width: 100%;
+    :hover {
+        background: ${color.blueDark2};
+    }
+`;
+
+const getContainerStyleByPosition = (position: Position) => {
+    switch (position) {
+        case 'top':
+            return top;
+        case 'bottom':
+            return bottom;
+        case 'left':
+            return left;
+        case 'right':
+            return right;
+    }
+};
+
+const left = css<Pick<DropdownProps, 'move'>>`
+    background: ${color.blueDark};
+    left: -0.5rem;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-100%) translateY(-50%);
+    &:after {
+        position: absolute;
+        content: '';
+        left: 100%;
+        transform: translateY(${(p) => (p.move ? `${p.move}%` : '-50%')});
+        border: ${arrowSize} solid transparent;
+        border-left-color: ${color.blueDark};
+    }
+`;
+
+const right = css<Pick<DropdownProps, 'move'>>`
+    background: ${color.blueDark};
+    position: absolute;
+    right: -0.5rem;
+    top: 50%;
+    transform: translateX(100%) translateY(-50%);
+    &:after {
+        position: absolute;
+        content: '';
+        right: 100%;
+        transform: translateY(${(p) => (p.move ? `${p.move}%` : '-50%')});
+        border: ${arrowSize} solid transparent;
+        border-right-color: ${color.blueDark};
+    }
+`;
+
+const top = css<Pick<DropdownProps, 'move'>>`
+    background: ${color.blueDark};
+    left: 50%;
+    position: absolute;
+    top: -0.5rem;
+    transform: translateX(-50%) translateY(-100%);
+    &:after {
+        position: absolute;
+        content: '';
+        bottom: 0;
+        transform: translateX(${(p) => (p.move ? `${p.move}%` : '-50%')})
+            translateY(100%);
+        border: ${arrowSize} solid transparent;
+        border-top-color: ${color.blueDark};
+    }
+`;
+
+export const DropdownStyles = {
+    DivArrowStyled,
+    DivContainer,
+    DivDropdownElementStyled,
+    ElementDiv,
+};

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { composeStories } from '@storybook/testing-react';
+import { fireEvent, waitFor, screen } from '@testing-library/react';
+import * as stories from './Dropdown.stories';
+import 'jest-styled-components';
+
+const { DropdownSelection } = composeStories(stories);
+
+describe('Default', () => {
+    let container: HTMLDivElement;
+    const dropdownParentId = 'dropdown-parent-test-id';
+    const dropdownElementId = 'element-test-id';
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        ReactDOM.render(<DropdownSelection position={'bottom'} />, container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        container.remove();
+    });
+
+    it('should render the parent', () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownParentId}"]`,
+        );
+        expect(element).not.toBeNull();
+    });
+
+    it('should display the menu on hover', async () => {
+        fireEvent.mouseOver(screen.getByTestId(dropdownParentId));
+
+        await waitFor(() => screen.getByTestId(dropdownParentId));
+        expect(
+            container.querySelector(`[data-testid="${dropdownElementId}"]`)
+                ?.innerHTML,
+        ).not.toBeNull();
+    });
+});

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,40 @@
+import { DropdownProps } from './types';
+import React, { useState } from 'react';
+import { DropdownStyles } from './Dropdown.styles';
+
+const { DivArrowStyled, DivContainer, DivDropdownElementStyled, ElementDiv } =
+    DropdownStyles;
+
+const Dropdown: React.FC<DropdownProps> = ({
+    children,
+    id = String(Date.now()),
+    move,
+    parent,
+    position,
+}) => {
+    const [showDropdown, setVisibility] = useState(false);
+    return (
+        <DivContainer
+            id={id}
+            onMouseEnter={() => setVisibility(true)}
+            onMouseLeave={() => setVisibility(false)}
+        >
+            <div data-testid={'dropdown-parent-test-id'}>{parent}</div>
+
+            {showDropdown && [
+                <DivArrowStyled position={position} move={move} />,
+                <DivDropdownElementStyled position={position}>
+                    {children.map((name) => {
+                        return (
+                            <div>
+                                <ElementDiv>{name}</ElementDiv>
+                            </div>
+                        );
+                    })}
+                </DivDropdownElementStyled>,
+            ]}
+        </DivContainer>
+    );
+};
+
+export default Dropdown;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -21,18 +21,22 @@ const Dropdown: React.FC<DropdownProps> = ({
         >
             <div data-testid={'dropdown-parent-test-id'}>{parent}</div>
 
-            {showDropdown && [
-                <DivArrowStyled position={position} move={move} />,
-                <DivDropdownElementStyled position={position}>
-                    {children.map((name) => {
-                        return (
-                            <div>
-                                <ElementDiv>{name}</ElementDiv>
-                            </div>
-                        );
-                    })}
-                </DivDropdownElementStyled>,
-            ]}
+            {showDropdown && (
+                <>
+                    <DivArrowStyled position={position} move={move} />,
+                    <DivDropdownElementStyled position={position}>
+                        {children.map((name) => {
+                            let key = 0;
+                            key++;
+                            return (
+                                <div key={key}>
+                                    <ElementDiv>{name}</ElementDiv>
+                                </div>
+                            );
+                        })}
+                    </DivDropdownElementStyled>
+                </>
+            )}
         </DivContainer>
     );
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -23,7 +23,7 @@ const Dropdown: React.FC<DropdownProps> = ({
 
             {showDropdown && (
                 <>
-                    <DivArrowStyled position={position} move={move} />,
+                    <DivArrowStyled position={position} move={move} />
                     <DivDropdownElementStyled position={position}>
                         {children.map((name) => {
                             let key = 0;

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,0 +1,2 @@
+export { default as Dropdown } from './Dropdown';
+export type { DropdownProps } from './types';

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -1,0 +1,32 @@
+export type Position = 'top' | 'bottom' | 'left' | 'right';
+
+export interface DropdownProps {
+    /**
+     * Set children which should have a tooltip
+     */
+    children: Array<React.ReactNode>;
+
+    /**
+     * The dropdown ID will be generated if not assigned
+     */
+    id?: string;
+
+    /**
+     * Moves the arrow +/- up/down/left/right (use responsibly, arrow can move the the X / Y axis indefinitely)
+     */
+    move?: number;
+
+    /**
+     * The parent element that triggers the dropdown selection
+     */
+    parent: React.ReactNode;
+
+    /**
+     * Set position of tooltip
+     */
+    position: Position;
+    /**
+     * The width of the dropdown menu
+     */
+    width?: number;
+}

--- a/src/components/DropdownElement/DropdownElement.stories.tsx
+++ b/src/components/DropdownElement/DropdownElement.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import colors from '../../styles/colors';
+import DropdownElement from '../DropdownElement/DropdownElement';
+import { iconTypes } from '../Icon/collection';
+
+export default {
+    title: 'UI/Dropdown Element',
+    component: DropdownElement,
+    argTypes: { onClick: { action: 'clicked' } },
+} as ComponentMeta<typeof DropdownElement>;
+
+const Template: ComponentStory<typeof DropdownElement> = (args) => (
+    <DropdownElement {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Logout = Template.bind({});
+Logout.args = {
+    icon: iconTypes.logOut,
+    iconColor: colors.red,
+    text: 'Logout',
+    textColor: colors.red,
+};

--- a/src/components/DropdownElement/DropdownElement.styles.tsx
+++ b/src/components/DropdownElement/DropdownElement.styles.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import colors from '../../styles/colors';
+import fonts from '../../styles/fonts';
+import DropdownElementProps from './types';
+
+const DivContainerStyled = styled.div<DropdownElementProps>`
+    background: ${(p) => (p.backgroundColor ? p.backgroundColor : '')};
+    cursor: pointer;
+    display: inline-block;
+`;
+
+const DivStyled = styled.div<
+    Pick<DropdownElementProps, 'width' | 'height' | 'onClick'>
+>`
+    display: flex;
+    flex-direction: row;
+    height: ${(p) => (p.height ? `${p.height}px` : 'auto')};
+    padding-left: 16px;
+    padding-right: 16px;
+    width: ${(p) => (p.width ? `${p.width}px` : 'auto')};
+`;
+
+const DivImageStyled = styled.div`
+    align-items: center;
+    display: flex;
+    padding-right: 8px;
+`;
+
+const DivTextStyled = styled.p<
+    Pick<DropdownElementProps, 'textColor' | 'textSize'>
+>`
+    align-items: center;
+    color: ${(p) => (p.textColor ? p.textColor : colors.white)};
+    display: flex;
+    font-size: ${(p) => (p.textSize ? `${p.textSize}px` : '')};
+    ${fonts.openSans};
+    ${fonts.textBold};
+`;
+
+export const DropdownElementStyles = {
+    DivContainerStyled,
+    DivImageStyled,
+    DivStyled,
+    DivTextStyled,
+};

--- a/src/components/DropdownElement/DropdownElement.styles.tsx
+++ b/src/components/DropdownElement/DropdownElement.styles.tsx
@@ -26,7 +26,7 @@ const DivImageStyled = styled.div`
     padding-right: 8px;
 `;
 
-const DivTextStyled = styled.p<
+const TextStyled = styled.p<
     Pick<DropdownElementProps, 'textColor' | 'textSize'>
 >`
     align-items: center;
@@ -41,5 +41,5 @@ export const DropdownElementStyles = {
     DivContainerStyled,
     DivImageStyled,
     DivStyled,
-    DivTextStyled,
+    TextStyled,
 };

--- a/src/components/DropdownElement/DropdownElement.test.tsx
+++ b/src/components/DropdownElement/DropdownElement.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { fireEvent } from '@testing-library/react';
+import { composeStories } from '@storybook/testing-react';
+import * as stories from './DropdownElement.stories';
+import 'jest-styled-components';
+
+const { Default } = composeStories(stories);
+const testClickEvent = jest.fn();
+
+describe('Default', () => {
+    let container: HTMLDivElement;
+    const dropdownElementId = 'dropdown-element-test-id';
+    const dropdownElementClickId = 'dropdown-element-click-test-id';
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        ReactDOM.render(<Default onClick={testClickEvent} />, container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        container.remove();
+    });
+
+    it('should render the component', () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementId}"]`,
+        );
+        expect(element).not.toBeNull();
+    });
+
+    it('should fire event when clicked', async () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementClickId}"]`,
+        );
+        element && fireEvent.click(element);
+        expect(testClickEvent).toHaveBeenCalled();
+    });
+});
+
+describe('Custom', () => {
+    let container: HTMLDivElement;
+    const dropdownElementId = 'dropdown-element-test-id';
+    const dropdownElementClickId = 'dropdown-element-click-test-id';
+    const dropdownElementTextId = 'dropdown-element-text-test-id';
+    const height = 50;
+    const width = 100;
+    const buttonText = 'Local Devchain Server';
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        ReactDOM.render(
+            <Default
+                height={height}
+                width={width}
+                text={buttonText}
+                textSize={20}
+                iconSize={30}
+                backgroundColor={'transparent'}
+                onClick={testClickEvent}
+            />,
+            container,
+        );
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        container.remove();
+    });
+
+    it('should render the component', () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementId}"]`,
+        );
+        expect(element).not.toBeNull();
+    });
+
+    it('should fire event when clicked', async () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementClickId}"]`,
+        );
+        element && fireEvent.click(element);
+        expect(testClickEvent).toHaveBeenCalled();
+    });
+
+    it(`should have set the width to ${width}`, () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementClickId}"]`,
+        );
+        expect(element?.getAttribute('width')).toBe(`${width}`);
+    });
+
+    it(`should have set the height to ${height}`, () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementClickId}"]`,
+        );
+        expect(element?.getAttribute('height')).toBe(`${height}`);
+    });
+
+    it('should have set the text', () => {
+        const element = container.querySelector(
+            `[data-testid="${dropdownElementTextId}"]`,
+        );
+        expect(element?.textContent).toBe(buttonText);
+    });
+});

--- a/src/components/DropdownElement/DropdownElement.tsx
+++ b/src/components/DropdownElement/DropdownElement.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../Icon';
 import { iconTypes } from '../Icon/collection';
 import React from 'react';
 
-const { DivContainerStyled, DivStyled, DivImageStyled, DivTextStyled } =
+const { DivContainerStyled, DivStyled, DivImageStyled, TextStyled } =
     DropdownElementStyles;
 
 const DropdownElement: React.FC<DropdownElementProps> = ({
@@ -14,7 +14,7 @@ const DropdownElement: React.FC<DropdownElementProps> = ({
     icon = iconTypes.check,
     iconColor = 'white',
     iconSize = 20,
-    id = String(Date.now()),
+    id,
     onClick,
     text = 'Text',
     textColor = 'white',
@@ -46,13 +46,13 @@ const DropdownElement: React.FC<DropdownElementProps> = ({
                 ) : (
                     ''
                 )}
-                <DivTextStyled
+                <TextStyled
                     data-testid={'dropdown-element-text-test-id'}
                     textColor={textColor}
                     textSize={textSize}
                 >
                     {text}
-                </DivTextStyled>
+                </TextStyled>
             </DivStyled>
         </DivContainerStyled>
     );

--- a/src/components/DropdownElement/DropdownElement.tsx
+++ b/src/components/DropdownElement/DropdownElement.tsx
@@ -1,0 +1,61 @@
+import colors from '../../styles/colors';
+import { DropdownElementProps } from './types';
+import { DropdownElementStyles } from './DropdownElement.styles';
+import { Icon } from '../Icon';
+import { iconTypes } from '../Icon/collection';
+import React from 'react';
+
+const { DivContainerStyled, DivStyled, DivImageStyled, DivTextStyled } =
+    DropdownElementStyles;
+
+const DropdownElement: React.FC<DropdownElementProps> = ({
+    backgroundColor = colors.blueDark,
+    height,
+    icon = iconTypes.check,
+    iconColor = 'white',
+    iconSize = 20,
+    id = String(Date.now()),
+    onClick,
+    text = 'Text',
+    textColor = 'white',
+    textSize = 14,
+    width,
+}: DropdownElementProps) => {
+    return (
+        <DivContainerStyled
+            backgroundColor={backgroundColor}
+            data-testid={'dropdown-element-test-id'}
+            icon={icon}
+            iconColor={iconColor}
+            id={id}
+        >
+            <DivStyled
+                data-testid={'dropdown-element-click-test-id'}
+                height={height}
+                width={width}
+                onClick={() => {
+                    {
+                        onClick ? onClick() : '';
+                    }
+                }}
+            >
+                {icon ? (
+                    <DivImageStyled>
+                        <Icon fill={iconColor} size={iconSize} svg={icon} />
+                    </DivImageStyled>
+                ) : (
+                    ''
+                )}
+                <DivTextStyled
+                    data-testid={'dropdown-element-text-test-id'}
+                    textColor={textColor}
+                    textSize={textSize}
+                >
+                    {text}
+                </DivTextStyled>
+            </DivStyled>
+        </DivContainerStyled>
+    );
+};
+
+export default DropdownElement;

--- a/src/components/DropdownElement/index.tsx
+++ b/src/components/DropdownElement/index.tsx
@@ -1,0 +1,2 @@
+export { default as DropdownElement } from './DropdownElement';
+export type { DropdownElementProps } from './types';

--- a/src/components/DropdownElement/types.ts
+++ b/src/components/DropdownElement/types.ts
@@ -1,0 +1,60 @@
+import { iconTypes } from '../Icon/collection';
+
+export interface DropdownElementProps {
+    /**
+     * The background color
+     */
+    backgroundColor?: string;
+
+    /**
+     * Static height
+     */
+    height?: number;
+
+    /**
+     * The icon next to the text
+     */
+    icon?: iconTypes;
+
+    /**
+     * The color of the icon
+     */
+    iconColor?: string;
+
+    /**
+     * Icon size
+     */
+    iconSize?: number;
+
+    /**
+     * The tooltip ID will be generated if not assigned
+     */
+    id?: string;
+
+    /**
+     * Runs a function when clicked
+     */
+    onClick?: () => void;
+
+    /**
+     * The text
+     */
+    text?: string;
+
+    /**
+     * The color of the text
+     */
+    textColor?: string;
+
+    /**
+     * Text size
+     */
+    textSize?: number;
+
+    /**
+     * Static width
+     */
+    width?: number;
+}
+
+export default DropdownElementProps;

--- a/src/components/DropdownElement/types.ts
+++ b/src/components/DropdownElement/types.ts
@@ -27,7 +27,7 @@ export interface DropdownElementProps {
     iconSize?: number;
 
     /**
-     * The tooltip ID will be generated if not assigned
+     * The dropdown id
      */
     id?: string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/CryptoCards';
+export * from './components/DropdownElement';
 export * from './components/Form';
 export * from './components/Icon';
 export * from './components/Illustrations';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/CryptoCards';
+export * from './components/Dropdown';
 export * from './components/DropdownElement';
 export * from './components/Form';
 export * from './components/Icon';


### PR DESCRIPTION
This is the component that can/should be used to use when creating a dropdown menu.
The only goal of this component is to be 100% customisable, it also allows to set `onClick` event to run a function when clicked.

Height and width are auto if not specified.
Text, icon, colours, size, everything customisable. 