### PR TITLE
Fix link to button optional defaults

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ const Button: React.FC<ButtonProps> = ({
     iconLayout = 'leading',
     id,
     isFullWidth = false,
-    onClick,
+    onClick = (e) => e.preventDefault(),
     size = 'regular',
     text = 'click',
     theme,

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -9,7 +9,7 @@ export interface ButtonProps {
     /**
      * the function to be called on click
      */
-    onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 
     /**
      * set the button to be interactive, or not

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -20,7 +20,7 @@ export interface FormProps {
     /**
      * Pass all the props a button could use
      */
-    buttonConfig: ButtonProps;
+    buttonConfig?: ButtonProps;
 
     /**
      * when the form passes validation the data is returned

--- a/src/components/LinkTo/LinkTo.tsx
+++ b/src/components/LinkTo/LinkTo.tsx
@@ -8,7 +8,7 @@ import { LinkStyled, FlexSpanStyled } from './LinkTo.styles';
 const LinkTo: React.FC<LinkToProps> = ({
     address,
     text,
-    type,
+    type = 'external',
     iconLayout = 'leading',
 }) => (
     <LinkStyled

--- a/src/components/LinkTo/types.ts
+++ b/src/components/LinkTo/types.ts
@@ -18,7 +18,7 @@ export interface LinkToProps {
     /**
      * set to an email link or a link to another website
      */
-    type: TTypeState;
+    type?: TTypeState;
 
     /**
      * set the position of the icon, or icon only


### PR DESCRIPTION
- LinkTo is external type by default
- Button onClick is now optional with `e.preventDeafult()` is default
- Form now takes buttonConfig as optional prop