### PR TITLE
fix(Modal): hasCancel boolean added, onCancelButtonPress event added

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -26,6 +26,10 @@ const Template: ComponentStory<typeof Modal> = (args) => {
                 console.log('pressed ok');
                 updateArgs({ isVisible: false });
             }}
+            onCloseButtonPressed={() => {
+                console.log('pressed close');
+                updateArgs({ isVisible: false });
+            }}
         />
     );
 };
@@ -34,6 +38,7 @@ export const Regular = Template.bind({});
 Regular.args = {
     id: 'regular',
     title: 'Confirm',
+    isVisible: true,
     children: [
         <div
             key={'0'}

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
-import { ModalProps } from './types';
 import colors from '../../styles/colors';
 import fonts from '../../styles/fonts';
+import { ModalProps } from './types';
 
-const ModalStyled = styled.div`
+type TStyleProps = Pick<ModalProps, 'isVisible' | 'hasCancel'>;
+
+export const ModalStyled = styled.div`
     ${fonts.text};
     background-color: ${colors.white};
     box-shadow: 0 4px 10px rgba(48, 71, 105, 0.1);
@@ -15,7 +17,7 @@ const ModalStyled = styled.div`
     width: 80%;
 `;
 
-const ModalHeader = styled.div`
+export const ModalHeader = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -31,18 +33,18 @@ const ModalHeader = styled.div`
     }
 `;
 
-const ModalContent = styled.div`
+export const ModalContent = styled.div`
     padding: 5px 32px 15px;
 `;
 
-const ModalFooter = styled.div`
-    display: flex;
-    justify-content: space-between;
+export const ModalFooter = styled.div<TStyleProps>`
     border-top: 1px solid ${colors.paleBlue2};
+    display: flex;
     padding: 15px 32px 20px;
+    justify-content: ${(p) => (p.hasCancel ? 'space-between' : 'flex-end')};
 `;
 
-const ModalWrapperStyled = styled.div<Pick<ModalProps, 'isVisible'>>`
+export const ModalWrapperStyled = styled.div<TStyleProps>`
     ${(p) => (p.isVisible ? 'display: grid;' : 'display: none;')};
     background: rgba(0, 0, 0, 0.3);
     bottom: 0;
@@ -52,13 +54,3 @@ const ModalWrapperStyled = styled.div<Pick<ModalProps, 'isVisible'>>`
     top: 0;
     z-index: 5;
 `;
-
-const ModalStyles = {
-    ModalContent,
-    ModalFooter,
-    ModalHeader,
-    ModalStyled,
-    ModalWrapperStyled,
-};
-
-export default ModalStyles;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ const Modal: React.FC<ModalProps> = ({
     cancelText = 'Cancel',
     children,
     hasCancel = true,
+    hasFooter = true,
     id = String(Date.now()),
     isCancelDisabled,
     isOkDisabled,
@@ -51,39 +52,41 @@ const Modal: React.FC<ModalProps> = ({
                 {children}
             </ModalContent>
 
-            <ModalFooter
-                data-testid={'modal-footer-test-id'}
-                hasCancel={hasCancel}
-            >
-                {hasCancel && (
+            {hasFooter && (
+                <ModalFooter
+                    data-testid={'modal-footer-test-id'}
+                    hasCancel={hasCancel}
+                >
+                    {hasCancel && (
+                        <Button
+                            data-testid={'modal-cancel-button-test-id'}
+                            disabled={isCancelDisabled}
+                            text={cancelText}
+                            onClick={
+                                onCancel
+                                    ? onCancel
+                                    : () => {
+                                          console.log('cancel triggered');
+                                      }
+                            }
+                            theme={'outline'}
+                        />
+                    )}
                     <Button
-                        data-testid={'modal-cancel-button-test-id'}
-                        disabled={isCancelDisabled}
-                        text={cancelText}
+                        data-testid={'modal-ok-button-test-id'}
                         onClick={
-                            onCancel
-                                ? onCancel
+                            onOk
+                                ? onOk
                                 : () => {
-                                      console.log('cancel triggered');
+                                      console.log('ok triggered');
                                   }
                         }
-                        theme={'outline'}
+                        disabled={isOkDisabled}
+                        text={okText}
+                        theme={'primary'}
                     />
-                )}
-                <Button
-                    data-testid={'modal-ok-button-test-id'}
-                    onClick={
-                        onOk
-                            ? onOk
-                            : () => {
-                                  console.log('ok triggered');
-                              }
-                    }
-                    disabled={isOkDisabled}
-                    text={okText}
-                    theme={'primary'}
-                />
-            </ModalFooter>
+                </ModalFooter>
+            )}
         </ModalStyled>
     </ModalWrapperStyled>
 );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,61 +1,61 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { ModalProps } from './types';
 import Button from '../Button/Button';
-import ModalStyles from './Modal.styles';
 import { iconTypes } from '../Icon/collection';
-
-const {
+import {
     ModalHeader,
     ModalStyled,
     ModalFooter,
     ModalContent,
     ModalWrapperStyled,
-} = ModalStyles;
+} from './Modal.styles';
 
 const Modal: React.FC<ModalProps> = ({
-    id = String(Date.now()),
-    children,
-    isOkDisabled,
-    isCancelDisabled,
-    isVisible = true,
     cancelText = 'Cancel',
+    children,
+    hasCancel = true,
+    id = String(Date.now()),
+    isCancelDisabled,
+    isOkDisabled,
+    isVisible = true,
     okText = 'Ok',
     onCancel,
+    onCloseButtonPressed,
     onOk,
     title,
-}: ModalProps) => {
-    const [visible, setVisibility] = useState(isVisible);
+}: ModalProps) => (
+    <ModalWrapperStyled
+        id={id}
+        isVisible={isVisible}
+        data-testid="modal-test-id"
+    >
+        <ModalStyled>
+            <ModalHeader data-testid={'modal-header-test-id'}>
+                <h3>{title}</h3>
+                <Button
+                    data-testid={'modal-close-test-id'}
+                    icon={iconTypes.x}
+                    iconLayout={'icon-only'}
+                    onClick={
+                        onCloseButtonPressed
+                            ? onCloseButtonPressed
+                            : () => {
+                                  console.log('close triggered');
+                              }
+                    }
+                    theme={'outline'}
+                />
+            </ModalHeader>
 
-    useEffect(() => {
-        setVisibility(isVisible);
-    }, [isVisible]);
+            <ModalContent id={'content'} data-testid={'modal-content-test-id'}>
+                {children}
+            </ModalContent>
 
-    return (
-        <ModalWrapperStyled
-            id={id}
-            isVisible={visible}
-            data-testid="modal-test-id"
-        >
-            <ModalStyled>
-                <ModalHeader data-testid={'modal-header-test-id'}>
-                    <h3>{title}</h3>
-                    <Button
-                        data-testid={'modal-close-test-id'}
-                        icon={iconTypes.x}
-                        iconLayout={'icon-only'}
-                        onClick={() => setVisibility(false)}
-                        theme={'outline'}
-                    />
-                </ModalHeader>
-
-                <ModalContent
-                    id={'content'}
-                    data-testid={'modal-content-test-id'}
-                >
-                    {children}
-                </ModalContent>
-
-                <ModalFooter data-testid={'modal-footer-test-id'}>
+            <ModalFooter
+                data-testid={'modal-footer-test-id'}
+                hasCancel={hasCancel}
+            >
+                {hasCancel && (
                     <Button
                         data-testid={'modal-cancel-button-test-id'}
                         disabled={isCancelDisabled}
@@ -64,28 +64,28 @@ const Modal: React.FC<ModalProps> = ({
                             onCancel
                                 ? onCancel
                                 : () => {
-                                      setVisibility(false);
+                                      console.log('cancel triggered');
                                   }
                         }
                         theme={'outline'}
                     />
-                    <Button
-                        data-testid={'modal-ok-button-test-id'}
-                        onClick={
-                            onOk
-                                ? onOk
-                                : () => {
-                                      console.log('ok triggered');
-                                  }
-                        }
-                        disabled={isOkDisabled}
-                        text={okText}
-                        theme={'primary'}
-                    />
-                </ModalFooter>
-            </ModalStyled>
-        </ModalWrapperStyled>
-    );
-};
+                )}
+                <Button
+                    data-testid={'modal-ok-button-test-id'}
+                    onClick={
+                        onOk
+                            ? onOk
+                            : () => {
+                                  console.log('ok triggered');
+                              }
+                    }
+                    disabled={isOkDisabled}
+                    text={okText}
+                    theme={'primary'}
+                />
+            </ModalFooter>
+        </ModalStyled>
+    </ModalWrapperStyled>
+);
 
 export default Modal;

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -10,6 +10,11 @@ export interface ModalProps {
     children: Array<React.ReactNode>;
 
     /**
+     * should the modal have a cancel button
+     */
+    hasCancel?: boolean;
+
+    /**
      * set text of 'Cancel' button
      */
     cancelText?: string;
@@ -38,6 +43,13 @@ export interface ModalProps {
      * Run function on 'Ok'
      */
     onOk?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+
+    /**
+     * Run function on 'X', you should prob use this event to set isVisible to false or ideally remove Modal from the render
+     */
+    onCloseButtonPressed?: (
+        event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => void;
 
     /*
      *  set text of 'Ok' button

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -15,6 +15,11 @@ export interface ModalProps {
     hasCancel?: boolean;
 
     /**
+     * should the modal have a footer
+     */
+    hasFooter?: boolean;
+
+    /**
      * set text of 'Cancel' button
      */
     cancelText?: string;


### PR DESCRIPTION
- hasCancel optional boolean added, default true, so cancel button can be hidden, CSS fix so ok is always aligned right even without a sibling
- remove all state React code, it should not govern its own state
- added onCancelButtonPress event so the next dev can flip isVisable or better yet unrender the Modal (docs added)
- minor alignment 