### PR TITLE
linebreak-style .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
         'no-tabs': ['error', { allowIndentationTabs: true }],
         'indent': 'off',
         'quotes': ['error', 'single', { avoidEscape: true }],
+        'linebreak-style': ['error', 'windows'],
     },
 };


### PR DESCRIPTION
Fix for eslint error when working on windows. Without this rule code for people on windows looks like this:

![image](https://user-images.githubusercontent.com/78314301/152506054-8e95442a-7c87-4738-b2d4-45c7f26a0543.png)

Since we have people working on different OS and code editors I think we should use this rule.

https://eslint.org/docs/rules/linebreak-style#windows