### PR TITLE
fixed: decorator for web3 components

### DIFF
--- a/src/decorators.tsx
+++ b/src/decorators.tsx
@@ -1,10 +1,35 @@
-import React from 'react';
-import { MoralisProvider } from 'react-moralis';
+import React, { useEffect } from 'react';
+import { MoralisProvider, useMoralis } from 'react-moralis';
 import { DecoratorFn } from '@storybook/react';
 
 export const moralisContext: DecoratorFn = (Story) => {
     const MORALIS_APP_ID = process.env.STORYBOOK_MORALIS_APP_ID;
     const MORALIS_SERVER_URL = process.env.STORYBOOK_MORALIS_SERVER_URL;
+
+    const Web3Initialize = () => {
+        const {
+            enableWeb3,
+            isAuthenticated,
+            isWeb3Enabled,
+            isWeb3EnableLoading,
+            isInitialized,
+        } = useMoralis();
+
+        useEffect(() => {
+            if (!isInitialized) return;
+            const connectorId = window.localStorage.getItem('connectorId');
+            if (isAuthenticated && !isWeb3Enabled && !isWeb3EnableLoading) {
+                enableWeb3({ provider: connectorId as any });
+            }
+        }, [
+            isAuthenticated,
+            isWeb3Enabled,
+            isInitialized,
+            isWeb3EnableLoading,
+        ]);
+
+        return null;
+    };
 
     return (
         <>
@@ -14,6 +39,7 @@ export const moralisContext: DecoratorFn = (Story) => {
                     serverUrl={MORALIS_SERVER_URL}
                 >
                     <Story />
+                    <Web3Initialize />
                 </MoralisProvider>
             ) : (
                 <>


### PR DESCRIPTION
For correct work of all web3 components inside StoryBook stories and having the same Moralis context, we need to use additional web3 connection enabling.