### PR TITLE
chore: exclude `crypto` from browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "http": false,
         "https": false,
         "os": false,
-        "stream": false
+        "stream": false,
+        "crypto": false
     },
     "scripts": {
         "analyze": "size-limit --why",


### PR DESCRIPTION
should make `size.yml` workflow pass