### PR TITLE
feat: just thinking ahead of possible ways this could have bad ux

### DIFF
--- a/src/components/Icon/Icon.styles.tsx
+++ b/src/components/Icon/Icon.styles.tsx
@@ -6,4 +6,6 @@ export const StyledIconDiv = styled.div`
     justify-content: center;
     align-items: center;
     line-height: 0px;
+    max-width: fit-content;
+    max-height: fit-content;
 `;


### PR DESCRIPTION
Giving a max width and height, so if a user just has one icon, by default it would span the whole, page. We don't want that 😅