### PR TITLE
feat: Revert prop added to Copy Button

### DIFF
--- a/src/components/CopyButton/CopyButton.stories.tsx
+++ b/src/components/CopyButton/CopyButton.stories.tsx
@@ -23,6 +23,7 @@ const Template: ComponentStory<typeof CopyButton> = () => {
             <Typography>With Love from Developers</Typography>
             <CopyButton
                 text="With Love from Developers"
+                revertIn={6500}
                 onCopy={() =>
                     notify({
                         type: 'success',

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -26,11 +26,20 @@ export const useCopyToClipboard = (): [CopiedValue, CopyFn] => {
     return [copiedText, copy];
 };
 
-const CopyButton: FC<CopyButtonProps> = ({ text, onCopy = () => {} }) => {
-    const [value, copy] = useCopyToClipboard();
+const CopyButton: FC<CopyButtonProps> = ({
+    text,
+    onCopy = () => {},
+    revertIn = 3000,
+}) => {
+    const [, copy] = useCopyToClipboard();
+    const [value, set] = useState(false);
 
     const copyToClipboard = (): void => {
         copy(`${text}`);
+        set(true);
+        setTimeout(() => {
+            set(false);
+        }, revertIn);
     };
 
     return (

--- a/src/components/CopyButton/types.ts
+++ b/src/components/CopyButton/types.ts
@@ -1,6 +1,7 @@
 export interface CopyButtonProps {
     text?: string | number;
     onCopy?: (e?: React.BaseSyntheticEvent) => void;
+    revertIn?: number;
 }
 export type CopiedValue = string | null;
 export type CopyFn = (text: string) => Promise<boolean>;


### PR DESCRIPTION
Added revertIn prop to `CopyButton`. <br>

It accepts a number in `ms` that is used to revert the `CopyButton` image to default after `revertIn` ms.

Usage (6.5 seconds):

```js
            <CopyButton
                text="With Love from Developers"
                revertIn={6500}
                onCopy={() =>
                    notify({
                        type: 'success',
                        message: 'Copied to clipboard',
                        title: 'New Notification',
                        position: 'topR',
                    })
                }
            />
```