### PR TITLE
fix(Typography): strict types removed

### DIFF
--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import styled from 'styled-components';
 import { CopyButton } from '../CopyButton';
 import { TypographyProps, variantType } from './types';
@@ -26,7 +26,7 @@ const getTag = (variant: variantType) => {
     }
 };
 
-const DynamicText = ({
+const DynamicText: FC<TypographyProps> = ({
     variant = 'body16',
     italic,
     monospace,
@@ -35,7 +35,7 @@ const DynamicText = ({
     iconSize,
     onCopy = () => {},
     ...otherProps
-}: TypographyProps) => {
+}) => {
     const Tag = getTag(variant);
 
     return (
@@ -45,7 +45,7 @@ const DynamicText = ({
             {copyable && (
                 <CopyButton
                     iconSize={iconSize}
-                    text={children}
+                    text={`${children}`}
                     onCopy={onCopy}
                 />
             )}

--- a/src/components/Typography/types.ts
+++ b/src/components/Typography/types.ts
@@ -30,7 +30,7 @@ export interface TypographyProps {
     /**
      * Children text
      */
-    children?: string | number;
+    children?: React.ReactNode;
 
     /**
      * Copies text to clipboard


### PR DESCRIPTION
fix for the issue when you pass children text:

![image](https://user-images.githubusercontent.com/78314301/156898928-70a79101-9a71-4479-8cbc-712e2d393438.png)
