### PR TITLE
feat(CheckBox): added useeffect for upd state from prop

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -718,8 +718,6 @@ describe('Checkbox - SwitchingText', () => {
         const textUpdated: HTMLSpanElement | null = container.querySelector(
             `[data-testid="${textTestID}"]`,
         );
-        expect(textUpdated?.textContent).toBe(
-            SwitchingText.args?.labelWhenChecked,
-        );
+        expect(textUpdated?.textContent).toBe(testLabelText);
     });
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CheckboxProps } from '.';
 import { Icon } from '../Icon';
 import { iconTypes } from '../Icon/collection';
@@ -22,6 +22,8 @@ const Checkbox: React.FC<CheckboxProps> = ({
         if (disabled) return;
         onChange(event);
     };
+
+    useEffect(() => setIsChecked(checked), [checked]);
 
     return (
         <StyledLabel


### PR DESCRIPTION
Since CheckBox has its own state `isChecked` we need to also listen to changes in the `checked` prop and update state.

BUG demo:
![CheckboxBug](https://user-images.githubusercontent.com/78314301/156920988-e6cdfeea-34e9-4510-aa25-e9e53b4685aa.gif)
 