### PR TITLE
feat: Card component accept ReactNode elements as title and descr

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -178,3 +178,20 @@ ProPlan.args = {
         </div>,
     ],
 };
+
+export const CustomFont = Template.bind({});
+CustomFont.args = {
+    tooltipText: 'Check this font out!',
+    children: [<div key={'0'}>{getModuleAnimation('Lazy NFT')}</div>],
+    title: (
+        <p style={{ fontFamily: 'Creepster, cursive' }}>
+            {'Such a nice font here!'}
+        </p>
+    ),
+    description: (
+        <p style={{ fontFamily: 'Creepster, cursive' }}>
+            {'Testing out some fancy fonts :)'}
+        </p>
+    ),
+    isDisabled: true,
+};

--- a/src/components/Card/types.ts
+++ b/src/components/Card/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 export interface CardProps {
     /**
      * set the ID of Card
@@ -12,7 +13,7 @@ export interface CardProps {
     /**
      * set the description of the card
      */
-    description?: string;
+    description?: string | ReactNode;
 
     /**
      * set if card is selected
@@ -22,7 +23,7 @@ export interface CardProps {
     /**
      * set title of card
      */
-    title?: string;
+    title?: string | ReactNode;
 
     /**
      * set text inside tooltip

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -91,6 +91,11 @@ const montserrat = css`
     font-family: 'Montserrat', sans-serif;
 `;
 
+const creepster = css`
+    @import url('//fonts.googleapis.com/css2?family=Creepster&display=swap');
+    font-family: 'Creepster', cursive;
+`;
+
 const fonts = {
     h1,
     h2,
@@ -107,6 +112,7 @@ const fonts = {
     textBold500,
     openSans,
     montserrat,
+    creepster,
 };
 
 export default fonts;


### PR DESCRIPTION
Enable `React Node` type as title and description for `Card` component:


<img width="290" alt="Screenshot 2022-03-09 at 17 48 24" src="https://user-images.githubusercontent.com/60792849/157489711-26d96d56-50ad-4069-b04c-952ef8223b98.png">


```js
export const CustomFont = Template.bind({});
CustomFont.args = {
    tooltipText: 'Check this font out!',
    children: [<div key={'0'}>{getModuleAnimation('Lazy NFT')}</div>],
    title: (
        <p style={{ fontFamily: 'Creepster, cursive' }}>
            {'Such a nice font here!'}
        </p>
    ),
    description: (
        <p style={{ fontFamily: 'Creepster, cursive' }}>
            {'Testing out some fancy fonts :)'}
        </p>
    ),
    isDisabled: true,
};
```