### PR TITLE
feat: custom close button for modal component

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -250,3 +250,65 @@ CustomFooter.args = {
     hasCancel: false,
     customFooter: <p id="Custom-Footer">Custom Footer Here</p>,
 };
+
+export const CustomCloseButton = Template.bind({});
+CustomCloseButton.args = {
+    id: 'regular',
+    title: 'Confirm',
+    isVisible: true,
+    closeButton: (
+        <Button
+            id="test-button-secondary-icon"
+            text="Custom close button"
+            theme="secondary"
+            type="button"
+        />
+    ),
+    children: [
+        <div
+            key={'0'}
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexDirection: 'column',
+            }}
+        >
+            <Icon svg={iconTypes.cloud} size={64} fill={colors.blueDark2} />
+            <p>Proceed uploading?</p>
+        </div>,
+    ],
+};
+
+export const CustomCloseRoundButton = Template.bind({});
+CustomCloseRoundButton.args = {
+    id: 'regular',
+    title: 'Confirm',
+    isVisible: true,
+    closeButton: (
+        <Button
+            icon="arrowCircleRight"
+            iconLayout="icon-only"
+            id="test-button-primary-icon-only"
+            onClick={() => {}}
+            text="Primary icon only"
+            theme="primary"
+            type="button"
+            radius={40}
+        />
+    ),
+    children: [
+        <div
+            key={'0'}
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexDirection: 'column',
+            }}
+        >
+            <Icon svg={iconTypes.cloud} size={64} fill={colors.blueDark2} />
+            <p>Proceed uploading?</p>
+        </div>,
+    ],
+};

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -67,3 +67,13 @@ export const CustomFooterStyled = styled.footer`
     display: flex;
     padding: 15px 32px 20px;
 `;
+
+export const CustomButtonStyle = styled.button`
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+`;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -9,6 +9,7 @@ import {
     DivStyledContent,
     DivStyled,
     CustomFooterStyled,
+    CustomButtonStyle,
 } from './Modal.styles';
 
 const Modal: React.FC<ModalProps> = ({
@@ -28,24 +29,39 @@ const Modal: React.FC<ModalProps> = ({
     title,
     width = '70vw',
     customFooter,
+    closeButton,
 }: ModalProps) => (
     <DivStyled id={id} isVisible={isVisible} data-testid="modal-test-id">
         <DivStyledWrap width={width}>
             <HeaderStyled data-testid={'modal-header-test-id'}>
                 {typeof title == 'string' ? <h3>{title}</h3> : title}
-                <Button
-                    data-testid={'modal-close-test-id'}
-                    icon={iconTypes.x}
-                    iconLayout={'icon-only'}
-                    onClick={
-                        onCloseButtonPressed
-                            ? onCloseButtonPressed
-                            : () => {
-                                  console.log('close triggered');
-                              }
-                    }
-                    theme={'outline'}
-                />
+                {closeButton ? (
+                    <CustomButtonStyle
+                        onClick={
+                            onCloseButtonPressed
+                                ? onCloseButtonPressed
+                                : () => {
+                                      console.log('close triggered');
+                                  }
+                        }
+                    >
+                        {closeButton}
+                    </CustomButtonStyle>
+                ) : (
+                    <Button
+                        data-testid={'modal-close-test-id'}
+                        icon={iconTypes.x}
+                        iconLayout={'icon-only'}
+                        onClick={
+                            onCloseButtonPressed
+                                ? onCloseButtonPressed
+                                : () => {
+                                      console.log('close triggered');
+                                  }
+                        }
+                        theme={'outline'}
+                    />
+                )}
             </HeaderStyled>
 
             <DivStyledContent

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,3 +1,6 @@
+import React from 'react';
+import type { ButtonProps } from '../Button';
+
 export interface ModalProps {
     /**
      * The ID of the modal will be generated automatically if not set
@@ -80,4 +83,9 @@ export interface ModalProps {
      * To Have a custom footer
      */
     customFooter?: JSX.Element;
+
+    /**
+     * To have a custom close button
+     */
+    closeButton?: ButtonProps;
 }


### PR DESCRIPTION
<img width="984" alt="image" src="https://user-images.githubusercontent.com/60792849/157503396-213ff4a8-bb88-4674-b7d7-18e1c65891c2.png">

Modal now accept a custom close button!

```js
CustomCloseRoundButton.args = {
    id: 'regular',
    title: 'Confirm',
    isVisible: true,
    closeButton: (
        <Button
            icon="arrowCircleRight"
            iconLayout="icon-only"
            id="test-button-primary-icon-only"
            onClick={() => {}}
            text="Primary icon only"
            theme="primary"
            type="button"
            radius={40}
        />
    ),
    children: [
        <div
            key={'0'}
            style={{
                display: 'flex',
                alignItems: 'center',
                justifyContent: 'center',
                flexDirection: 'column',
            }}
        >
            <Icon svg={iconTypes.cloud} size={64} fill={colors.blueDark2} />
            <p>Proceed uploading?</p>
        </div>,
    ],
};

```