### PR TITLE
BannerStrip: Add margin and remove padding from button

### DIFF
--- a/src/components/BannerStrip/BannerStrip.styles.ts
+++ b/src/components/BannerStrip/BannerStrip.styles.ts
@@ -15,6 +15,12 @@ const section = css`
     width: 100vw;
     z-index: 10001;
 
+    button {
+        padding: 0 8px;
+        margin: 2px 6px;
+        border: 0;
+    }
+
     strong {
         margin: 0 8px;
         padding: 2px 8px;
@@ -22,20 +28,7 @@ const section = css`
     }
 `;
 
-const button = css`
-    background-color: inherit;
-    border-radius: 25px;
-    border: 2px solid ${color.white};
-    color: ${color.white};
-    font-size: 14px;
-    font-weight: 600;
-    margin: 0 12px;
-    padding: 2px 8px;
-    white-space: nowrap;
-`;
-
 const bannerStripStyles = {
-    button,
     section,
 };
 

--- a/src/components/BannerStrip/BannerStrip.tsx
+++ b/src/components/BannerStrip/BannerStrip.tsx
@@ -20,8 +20,8 @@ const getBackgroundColor = (type: string) => {
 };
 
 const Section = styled.section<Pick<BannerStripProps, 'type' | 'height'>>`
-    ${fonts.text}
-    ${bannerStripStyles.section}
+    ${fonts.text};
+    ${bannerStripStyles.section};
     background-color: ${(p) => p.type && getBackgroundColor(p.type)};
     height: ${({ height }) => height};
 `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35369843/157504318-081dc1b4-ab1c-494b-9c56-d084432b6411.png)

Things done: closes #237 
- Removed padding top and bottom from button
- Added small margin to the button
- Removed border from button since it was not looking with it when button is large (let me know if this needs to reverted)
- Removed unused styles from the file

Ran the BannerStrip test file after these changes and all tests passed. 
![image](https://user-images.githubusercontent.com/35369843/157504999-eb28caf2-9040-4d1a-8ebd-99dfba8268dd.png)
