### PR TITLE
feat: added story and sizing on illustration components

### DIFF
--- a/src/components/Illustrations/Illustration.stories.tsx
+++ b/src/components/Illustrations/Illustration.stories.tsx
@@ -90,3 +90,10 @@ export const Bundle = Template.bind({});
 Bundle.args = {
     logo: 'bundle',
 };
+
+export const CustomSizing = Template.bind({});
+CustomSizing.args = {
+    logo: 'comingSoon',
+    width: '150px',
+    height: '150px',
+};

--- a/src/components/Illustrations/Illustration.tsx
+++ b/src/components/Illustrations/Illustration.tsx
@@ -58,11 +58,15 @@ const getLogo = (logo: Chain | Logo, width?: Size, height?: Size) => {
     }
 };
 
-const StyledIllustration = styled.div`
+const StyledIllustration = styled.div<
+    Pick<IllustrationProps, 'width' | 'height'>
+>`
     ${resetCSS}
     display: flex;
     justify-content: center;
     align-items: center;
+    width: ${(props) => props.width};
+    height: ${(props) => props.height};
 `;
 
 const Illustration: React.FC<IllustrationProps> = ({
@@ -72,7 +76,7 @@ const Illustration: React.FC<IllustrationProps> = ({
     height,
 }: IllustrationProps) => {
     return (
-        <StyledIllustration id={id}>
+        <StyledIllustration width={width} height={height} id={id}>
             {getLogo(logo, width, height)}
         </StyledIllustration>
     );

--- a/src/components/Illustrations/types.ts
+++ b/src/components/Illustrations/types.ts
@@ -31,6 +31,13 @@ export interface IllustrationProps {
      */
     logo: Chain | Logo;
 
+    /**
+     * Height of Illustration
+     */
     width?: Size;
+
+    /**
+     * Width of illustration
+     */
     height?: Size;
 }


### PR DESCRIPTION
Fixed the custom width and heigh elements for illlustration svgs:

<img width="895" alt="Screen Shot 2022-03-10 at 9 53 04 AM" src="https://user-images.githubusercontent.com/62478924/157687789-036f3c2d-dcc3-44a9-9a03-81241908c142.png">
