### PR TITLE
fix: Input component hide type <password> by default

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -40,7 +40,7 @@ const Input: React.FC<InputProps> = ({
     const [isInputHidden, setIsInputHidden] = useState(inputHidden);
     const [invalidMessage, setInvalidMessage] = useState(errorMessage);
 
-    useEffect(() => setIsInputHidden(inputHidden), [inputHidden]);
+    useEffect(() => setIsInputHidden(type === 'password'), [inputHidden]);
     useEffect(() => setCurrentState(state), [state]);
     useEffect(() => setMainType(type), [type]);
 


### PR DESCRIPTION
The `<Input>` component hides type "password" by default.

![Alt Text](https://media.giphy.com/media/VSUW30P9BDAqqG1ejs/giphy.gif)