### PR TITLE
[bug]: Fix Modal Header and Footer

### DIFF
--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -5,7 +5,7 @@ import { ModalProps } from './types';
 
 type TStyleProps = Pick<
     ModalProps,
-    'isVisible' | 'hasCancel' | 'width' | 'canOverflow'
+    'isVisible' | 'hasCancel' | 'width' | 'canOverflow' | 'fixedMode'
 >;
 
 const overflow = (): string => {
@@ -34,12 +34,13 @@ export const DivStyledWrap = styled.div<TStyleProps>`
 
 export const HeaderStyled = styled.header<{
     title: any;
+    fixedMode: boolean;
 }>`
+    ${(p) => p.fixedMode && 'position: sticky;top: 0;background-color: white;'}
     display: flex;
     align-items: center;
-    justify-content: ${(p) => (p.title ? 'space-between' : 'flex-end')};
     padding: 24px 32px 10px;
-
+    justify-content: ${(p) => (p.title ? 'space-between' : 'flex-end')};
     div {
         border-color: ${colors.blue};
         border-radius: 15px;
@@ -60,6 +61,8 @@ export const DivStyledContent = styled.div`
 `;
 
 export const FooterStyled = styled.footer<TStyleProps>`
+    ${(p) =>
+        p.fixedMode && 'position: sticky;bottom: 0;background-color: white;'}
     border-top: 1px solid ${colors.paleBlue2};
     display: flex;
     padding: 15px 32px 20px;
@@ -77,7 +80,9 @@ export const DivStyled = styled.div<TStyleProps>`
     z-index: 5;
 `;
 
-export const CustomFooterStyled = styled.footer`
+export const CustomFooterStyled = styled.footer<TStyleProps>`
+    ${(p) =>
+        p.fixedMode && 'position: sticky;bottom: 0;background-color: white;'}
     border-top: 1px solid ${colors.paleBlue2};
     display: flex;
     padding: 15px 32px 20px;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ import {
 const Modal: React.FC<ModalProps> = ({
     cancelText = 'Cancel',
     children,
+    fixedMode = false,
     hasCancel = true,
     hasFooter = true,
     id = String(Date.now()),
@@ -59,6 +60,7 @@ const Modal: React.FC<ModalProps> = ({
                 <HeaderStyled
                     data-testid={'modal-header-test-id'}
                     title={title}
+                    fixedMode={fixedMode}
                 >
                     {typeof title == 'string' ? <h3>{title}</h3> : title}
                     {closeButton ? (
@@ -89,6 +91,7 @@ const Modal: React.FC<ModalProps> = ({
                     <FooterStyled
                         data-testid={'modal-footer-test-id'}
                         hasCancel={hasCancel}
+                        fixedMode={fixedMode}
                     >
                         {hasCancel && (
                             <Button
@@ -111,7 +114,9 @@ const Modal: React.FC<ModalProps> = ({
                 )}
 
                 {customFooter && (
-                    <CustomFooterStyled>{customFooter}</CustomFooterStyled>
+                    <CustomFooterStyled fixedMode={fixedMode}>
+                        {customFooter}
+                    </CustomFooterStyled>
                 )}
             </DivStyledWrap>
         </DivStyled>

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -28,6 +28,11 @@ export interface ModalProps {
     cancelText?: string;
 
     /**
+     * set to true to fix header and footer
+     */
+    fixedMode?: boolean;
+
+    /**
      * set if 'Cancel' button is disabled
      */
     isCancelDisabled?: boolean;


### PR DESCRIPTION
closes #223 
Made header and footer sticky (also added same style for custom footer)
Since style are added on header and footer elements itself so don't need to take care of no header and footer scenario.
Let me know if anything needs to be changed 

https://user-images.githubusercontent.com/35369843/159119796-8feb0f3b-8fc9-4332-98ec-a1c5d2f49467.mp4
