### PR TITLE
feat: transparent button

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -433,3 +433,15 @@ PrimaryWithIconOnlyRound.args = {
     type: 'button',
     radius: 20,
 };
+
+export const TransparentButton = Template.bind({});
+TransparentButton.args = {
+    icon: iconTypes.plus,
+    iconLayout: 'icon-only',
+    id: 'test-button-primary-icon-only',
+    theme: 'secondary',
+    color: 'red',
+    type: 'button',
+    radius: 20,
+    isTransparent: true,
+};

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 import type { ButtonProps } from './types';
-import { initialStyles, isLoadingMode } from './styles/inititalStyles';
+import {
+    initialStyles,
+    isLoadingMode,
+    transparent,
+    hoverEffect,
+} from './styles/inititalStyles';
 import {
     outlineLarge,
     outlineRegular,
@@ -136,4 +141,6 @@ export const ButtonStyled = styled.button<TStyleProps>`
     ${(p) => p.radius && `border-radius: ${p.radius}px;`}
 
     ${(p) => p.iconColor && getIconColor(p.iconColor)}
+
+    ${(p) => (p.isTransparent ? transparent : hoverEffect)}
 `;

--- a/src/components/Button/styles/inititalStyles.ts
+++ b/src/components/Button/styles/inititalStyles.ts
@@ -65,3 +65,11 @@ export const isLoadingMode = css`
 export const transparent = css`
     background-color: transparent;
 `;
+
+export const hoverEffect = css`
+    :hover {
+        :after {
+            background-color: ${getShade('dark', 10)};
+        }
+    }
+`;


### PR DESCRIPTION
Added back the `transparent` button. Used to remove background to any `secondary` type button. <br>
This does simulate an icon, but with onclick property