### PR TITLE
added the props:headerHasBottomBorder to the modal component

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -65,6 +65,26 @@ Regular.args = {
     ],
 };
 
+export const BorderedHeader = Template.bind({});
+BorderedHeader.args = {
+    id: 'regular',
+    title: 'Bordered Header',
+    isVisible: true,
+    headerHasBottomBorder: true,
+    children: [
+        <div
+            key={'0'}
+            style={{
+                display: 'grid',
+                placeItems: 'center',
+            }}
+        >
+            <Icon svg={iconTypes.cloud} size={64} fill={colors.blueDark2} />
+            <p>This is a demo on how to use <em>headerHasBottomBorder</em> props?</p>
+        </div>,
+    ],
+};
+
 export const ButtonsDisabled = Template.bind({});
 ButtonsDisabled.args = {
     id: 'disabled',

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -35,12 +35,15 @@ export const DivStyledWrap = styled.div<TStyleProps>`
 export const HeaderStyled = styled.header<{
     title: any;
     fixedMode: boolean;
+    headerHasBottomBorder: boolean;
 }>`
     ${(p) => p.fixedMode && 'position: sticky;top: 0;background-color: white;'}
-    display: flex;
     align-items: center;
-    padding: 24px 32px 10px;
+    display: flex;
+    padding: 28px 32px 24px;
     justify-content: ${(p) => (p.title ? 'space-between' : 'flex-end')};
+    border-bottom: ${(p) => (p.headerHasBottomBorder ? `1px solid ${colors.paleBlue2}` : undefined)};
+    
     div {
         border-color: ${colors.blue};
         border-radius: 15px;
@@ -49,6 +52,8 @@ export const HeaderStyled = styled.header<{
     h3 {
         color: ${colors.blue};
         padding-right: 8px;
+        margin-block-start: 0;
+        margin-block-end: 0;
     }
 
     button {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ import {
 const Modal: React.FC<ModalProps> = ({
     cancelText = 'Cancel',
     children,
+    headerHasBottomBorder = false,
     fixedMode = false,
     hasCancel = true,
     hasFooter = true,
@@ -60,6 +61,7 @@ const Modal: React.FC<ModalProps> = ({
                     data-testid={'modal-header-test-id'}
                     title={title}
                     fixedMode={fixedMode}
+                    headerHasBottomBorder={headerHasBottomBorder}
                 >
                     {typeof title == 'string' ? <h3>{title}</h3> : title}
                     {closeButton ? (

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -28,6 +28,11 @@ export interface ModalProps {
     cancelText?: string;
 
     /**
+     * should the header component have a bottom border
+     */
+    headerHasBottomBorder?: boolean;
+
+    /**
      * set to true to fix header and footer
      */
     fixedMode?: boolean;


### PR DESCRIPTION
This PR will add bottom border to header of a modal component
the flag name is: headerHasBottomBorder
type is: boolean
default value: false

I also added an example to the story file to enable quick access to the example(demo)

<img width="1440" alt="Screenshot 2022-03-22 at 15 13 25" src="https://user-images.githubusercontent.com/16763860/159501817-8a3776c6-78b6-46a3-8a57-c2ff13a64a54.png">

