### PR TITLE
fix: tooltipText prop in Card component now accepts JSX.Element as well

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -31,7 +31,11 @@ const Template: ComponentStory<typeof Card> = (args) => {
 
 export const Regular = Template.bind({});
 Regular.args = {
-    tooltipText: 'Lorem Ipsum Dole met sai souni lokomit anici trenicid',
+    tooltipText: (
+        <span style={{ width: 200 }}>
+            'Lorem Ipsum Dole met sai souni lokomit anici trenicid'
+        </span>
+    ),
     children: [<div key={'0'}>{getModuleAnimation(undefined)}</div>],
     title: 'dApp',
     description: 'Click to create a dApp',

--- a/src/components/Card/types.ts
+++ b/src/components/Card/types.ts
@@ -28,7 +28,7 @@ export interface CardProps {
     /**
      * set text inside tooltip
      */
-    tooltipText?: string;
+    tooltipText?: JSX.Element | string;
 
     /**
      * Set the state disabled state of the cart


### PR DESCRIPTION
![Alt Text](https://media.giphy.com/media/g2HJZalByAPWHp7BRW/giphy.gif)

The `Card` component now accepts JSX Element as `tooltipText`. This allows to set a custom width to the text and uses the `Tooltip` functionality fully.