### PR TITLE
Fix checkbox 2 clicks

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -41,6 +41,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
 
             <StyledInput
                 data-testid="test-checkbox-input"
+                defaultChecked={isChecked}
                 disabled={disabled}
                 id={id}
                 layout={layout}


### PR DESCRIPTION
closes #326 
Fixed by passing defaultChecked attribute to input element