### PR TITLE
feat(Credentials): added text color customization

### DIFF
--- a/src/components/Credentials/Credentials.stories.tsx
+++ b/src/components/Credentials/Credentials.stories.tsx
@@ -36,3 +36,13 @@ export const OneLine = Template.bind({});
 OneLine.args = {
     text: 'https://xj5hyiafwkhn.moralis.io:2053/servers',
 };
+
+export const WithCustomColors = Template.bind({});
+WithCustomColors.args = {
+    icon: 'windows',
+    iconColor: 'green',
+    title: 'CLI API Key:',
+    titleColor: 'blue',
+    text: 'https://xj5hyiafwkhn.moralis.io:2053/servers',
+    textColor: 'red',
+};

--- a/src/components/Credentials/Credentials.tsx
+++ b/src/components/Credentials/Credentials.tsx
@@ -14,11 +14,13 @@ const Credentials: FC<ICredentialsProps> = ({
     hasCopyButton = true,
     hasHideButton = true,
     title,
+    titleColor,
     icon,
     iconColor,
     iconSize,
     isHidden = false,
     text,
+    textColor = color.blueDark,
     width = 'auto',
     hiddenText = '•••••••••••••••••••••••••••••••',
 }) => {
@@ -30,6 +32,7 @@ const Credentials: FC<ICredentialsProps> = ({
         <CredentialsStyled width={width} data-testid="test-credentials">
             <CredentialsHeader
                 title={title}
+                titleColor={titleColor}
                 icon={icon}
                 iconColor={iconColor}
                 iconSize={iconSize}
@@ -37,7 +40,7 @@ const Credentials: FC<ICredentialsProps> = ({
             <PreformattedStyled>
                 <Typography
                     monospace
-                    color={color.blueDark}
+                    color={textColor}
                     data-testid="cred-test-text"
                 >
                     {isValueHidden ? hiddenText : text}

--- a/src/components/Credentials/components/CredentialsHeader.tsx
+++ b/src/components/Credentials/components/CredentialsHeader.tsx
@@ -14,6 +14,7 @@ const HeaderStyled = styled.div`
 
 const CredentialsHeader: FC<ICredentialsHeaderProps> = ({
     title,
+    titleColor = color.blueDark,
     icon,
     iconColor = color.grey,
     iconSize = 24,
@@ -34,7 +35,7 @@ const CredentialsHeader: FC<ICredentialsHeaderProps> = ({
                 <Typography
                     variant="body16"
                     weight="600"
-                    color={color.blueDark}
+                    color={titleColor}
                     data-testid="cred-test-header-text"
                 >
                     {title}

--- a/src/components/Credentials/types.ts
+++ b/src/components/Credentials/types.ts
@@ -30,6 +30,11 @@ export interface ICredentialsProps extends ICredentialsHeaderProps {
     text: string;
 
     /**
+     * color of the text
+     */
+    textColor?: string | typeof color;
+
+    /**
      * width of component
      * default is "auto"
      */
@@ -40,6 +45,11 @@ export interface ICredentialsHeaderProps {
      * header text
      */
     title?: string | typeof Typography;
+
+    /**
+     * color of the title
+     */
+    titleColor?: string | typeof color;
 
     /**
      * header Icon


### PR DESCRIPTION
Added text color customization for `Credentials`

![image](https://user-images.githubusercontent.com/78314301/161936061-2e78d657-badb-4ffc-a606-c5310ed4d9bd.png)
