### PR TITLE
React18 refactor banner strip and styles

### DIFF
--- a/src/components/BannerStrip/BannerStrip.styles.ts
+++ b/src/components/BannerStrip/BannerStrip.styles.ts
@@ -1,7 +1,23 @@
-import { css } from 'styled-components';
+import styled from 'styled-components';
 import color from '../../styles/colors';
+import fonts from '../../styles/fonts';
+import { BannerStripProps } from './types';
 
-const section = css`
+const getBackgroundColor = (type: string) => {
+    switch (type) {
+        case 'success':
+            return color.green;
+        case 'warning':
+            return color.yellow;
+        case 'error':
+            return color.red;
+        default:
+            return color.blue;
+    }
+};
+
+const SectionStyled = styled.section<Pick<BannerStripProps, 'type' | 'height'>>`
+    ${fonts.text};
     align-items: center;
     color: ${color.white};
     display: flex;
@@ -14,6 +30,8 @@ const section = css`
     top: 0;
     width: 100vw;
     z-index: 10001;
+    background-color: ${(p) => p.type && getBackgroundColor(p.type)};
+    height: ${({ height }) => height};
 
     button {
         padding: 0 8px;
@@ -28,8 +46,4 @@ const section = css`
     }
 `;
 
-const bannerStripStyles = {
-    section,
-};
-
-export default bannerStripStyles;
+export default { SectionStyled };

--- a/src/components/BannerStrip/BannerStrip.test.tsx
+++ b/src/components/BannerStrip/BannerStrip.test.tsx
@@ -1,153 +1,81 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render, screen } from '@testing-library/react';
 import { composeStories } from '@storybook/testing-react';
 import * as stories from './BannerStrip.stories';
-import 'jest-styled-components';
 import color from '../../styles/colors';
 import rgbToHex from '../../utils/rgbToHex';
 
 const { Standard, StandardWithButton, Warning, Error, Success } =
     composeStories(stories);
 
-describe('Banner Strip - Standard', () => {
-    let container: HTMLDivElement;
-    const testId = 'banner-strip';
+const testId = 'banner-strip';
+
+test('Renders Standard', () => {
     const testText = 'Hey this is a notification you should check out';
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-        ReactDOM.render(<Standard />, container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-    it('renders the component', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element).not.toBeNull();
-    });
-    it('renders text correctly', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element?.textContent).toBe(testText);
-    });
-    it('renders will not render a button', () => {
-        const childElement = container.querySelector(
-            `[data-testid="${testId}"] > button`,
-        );
-        expect(childElement).toBeNull();
-    });
-    it('renders Standard with blue background', () => {
-        const element: HTMLElement | null = container.querySelector(
-            `[data-testid="${testId}"]`,
-        );
-        const styles = element && getComputedStyle(element);
-        const bgColorHex =
-            styles && rgbToHex(styles.backgroundColor).toUpperCase();
-        expect(bgColorHex).toBe(color.blue);
-    });
+    render(<Standard />);
+    const element = screen.getByTestId(testId);
+    expect(element).not.toBeNull();
+    expect(element.textContent).toBe(testText);
+    expect(element.lastChild?.nodeName).not.toBe('BUTTON');
+
+    const styles = element && getComputedStyle(element);
+    const backgroundColorHex =
+        styles && rgbToHex(styles.backgroundColor).toUpperCase();
+    expect(backgroundColorHex).toBe(color.blue);
 });
 
-describe('Banner Strip - With Button', () => {
-    let container: HTMLDivElement;
-    const testId = 'banner-strip';
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-        ReactDOM.render(<StandardWithButton />, container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-    it('renders the component', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element).not.toBeNull();
-    });
-    it('renders button correctly', () => {
-        const childElement = container.querySelector(
-            `[data-testid="${testId}"] > button`,
-        );
-        expect(childElement).not.toBeNull();
-    });
+test('Renders Standard with Button', () => {
+    const testText = StandardWithButton.args?.text;
+    render(<StandardWithButton />);
+    const element = screen.getByTestId(testId);
+    expect(element).not.toBeNull();
+    expect(element.firstChild?.textContent).toBe(testText);
+    expect(element.lastChild?.nodeName).toBe('BUTTON');
+
+    const styles = element && getComputedStyle(element);
+    const backgroundColorHex =
+        styles && rgbToHex(styles.backgroundColor).toUpperCase();
+    expect(backgroundColorHex).toBe(color.blue);
 });
 
-describe('Banner Strip - Warning', () => {
-    let container: HTMLDivElement;
-    const testId = 'banner-strip';
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-        ReactDOM.render(<Warning />, container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-    it('renders the component', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element).not.toBeNull();
-    });
-    it('renders Warning with yellow background', () => {
-        const element: HTMLElement | null = container.querySelector(
-            `[data-testid="${testId}"]`,
-        );
-        const styles = element && getComputedStyle(element);
-        const bgColorHex =
-            styles && rgbToHex(styles.backgroundColor).toUpperCase();
-        expect(bgColorHex).toBe(color.yellow);
-    });
+test('Renders Warning', () => {
+    const testText = Warning.args?.text;
+    render(<Warning />);
+    const element = screen.getByTestId(testId);
+    expect(element).not.toBeNull();
+    expect(element.firstChild?.textContent).toBe(testText);
+    expect(element.lastChild?.nodeName).not.toBe('BUTTON');
+
+    const styles = element && getComputedStyle(element);
+    const backgroundColorHex =
+        styles && rgbToHex(styles.backgroundColor).toUpperCase();
+    expect(backgroundColorHex).toBe(color.yellow);
 });
 
-describe('Banner Strip - Error', () => {
-    let container: HTMLDivElement;
-    const testId = 'banner-strip';
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-        ReactDOM.render(<Error />, container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-    it('renders the component', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element).not.toBeNull();
-    });
-    it('renders Error with blue background', () => {
-        const element: HTMLElement | null = container.querySelector(
-            `[data-testid="${testId}"]`,
-        );
-        const styles = element && getComputedStyle(element);
-        const bgColorHex =
-            styles && rgbToHex(styles.backgroundColor).toUpperCase();
-        expect(bgColorHex).toBe(color.red);
-    });
+test('Renders Error', () => {
+    const testText = Error.args?.text;
+    render(<Error />);
+    const element = screen.getByTestId(testId);
+    expect(element).not.toBeNull();
+    expect(element.firstChild?.textContent).toBe(testText);
+    expect(element.lastChild?.nodeName).not.toBe('BUTTON');
+
+    const styles = element && getComputedStyle(element);
+    const backgroundColorHex =
+        styles && rgbToHex(styles.backgroundColor).toUpperCase();
+    expect(backgroundColorHex).toBe(color.red);
 });
 
-describe('Banner Strip - Success', () => {
-    let container: HTMLDivElement;
-    const testId = 'banner-strip';
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-        ReactDOM.render(<Success />, container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-    it('renders the component', () => {
-        const element = container.querySelector(`[data-testid="${testId}"]`);
-        expect(element).not.toBeNull();
-    });
-    it('renders Success with green background', () => {
-        const element: HTMLElement | null = container.querySelector(
-            `[data-testid="${testId}"]`,
-        );
-        const styles = element && getComputedStyle(element);
-        const bgColorHex =
-            styles && rgbToHex(styles.backgroundColor).toUpperCase();
-        expect(bgColorHex).toBe(color.green);
-    });
+test('Renders Success', () => {
+    const testText = Success.args?.text;
+    render(<Success />);
+    const element = screen.getByTestId(testId);
+    expect(element).not.toBeNull();
+    expect(element.firstChild?.textContent).toBe(testText);
+    expect(element.lastChild?.nodeName).not.toBe('BUTTON');
+
+    const styles = element && getComputedStyle(element);
+    const backgroundColorHex =
+        styles && rgbToHex(styles.backgroundColor).toUpperCase();
+    expect(backgroundColorHex).toBe(color.green);
 });

--- a/src/components/BannerStrip/BannerStrip.tsx
+++ b/src/components/BannerStrip/BannerStrip.tsx
@@ -1,30 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
-import bannerStripStyles from './BannerStrip.styles';
-import color from '../../styles/colors';
-import fonts from '../../styles/fonts';
 import { BannerStripProps } from '.';
 import { Button } from '../Button';
+import styles from './BannerStrip.styles';
 
-const getBackgroundColor = (type: string) => {
-    switch (type) {
-        case 'success':
-            return color.green;
-        case 'warning':
-            return color.yellow;
-        case 'error':
-            return color.red;
-        default:
-            return color.blue;
-    }
-};
-
-const Section = styled.section<Pick<BannerStripProps, 'type' | 'height'>>`
-    ${fonts.text};
-    ${bannerStripStyles.section};
-    background-color: ${(p) => p.type && getBackgroundColor(p.type)};
-    height: ${({ height }) => height};
-`;
+const { SectionStyled } = styles;
 
 const BannerStrip: React.FC<BannerStripProps> = ({
     buttonConfig,
@@ -33,10 +12,10 @@ const BannerStrip: React.FC<BannerStripProps> = ({
     text,
     type = 'standard',
 }) => (
-    <Section type={type} height={height} data-testid="banner-strip">
+    <SectionStyled type={type} height={height} data-testid="banner-strip">
         <strong>{text}</strong>
         {buttonDisplayed && <Button {...buttonConfig} />}
-    </Section>
+    </SectionStyled>
 );
 
 export default BannerStrip;


### PR DESCRIPTION
- tests meet React18 standards
- all stories are tested
- all layouts / setups are rendered in stories
- scoped CSS without named exports
closes #359 
I have some doubts here.
1. stories file also uses named export. Does that also needs to be scoped?
2. In the section styles, z-index: 1001 is used. But what if we have a navbar and a bannerstrip on the page and user tries to scroll on that page.
In this case the bannerstrip would end up getting on top of navbar. 
Let me know if my understanding is correct or am i missing something. Thanks.