### PR TITLE
React18 refactor Icon

### DIFF
--- a/src/components/Icon/Icon.styles.tsx
+++ b/src/components/Icon/Icon.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const StyledIconDiv = styled.div`
+const StyledIconDiv = styled.div`
     align-items: center;
     display: flex;
     flex-direction: column;
@@ -8,3 +8,5 @@ export const StyledIconDiv = styled.div`
     line-height: 0px;
     pointer-events: none;
 `;
+
+export default { StyledIconDiv };

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,5 +1,5 @@
+import { render, screen } from '@testing-library/react';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { IconProps, Icon, iconTypes } from '.';
 import color from '../../styles/colors';
 import { TIconType } from './collection';
@@ -23,62 +23,36 @@ const renderComponent = (props: Partial<IconProps>) => {
     return <Icon {...setState(props)} />;
 };
 
-describe('Icon - render', () => {
-    let container: HTMLDivElement;
-    const testIcon = 'mail icon';
-    const testSize = defaultState.size;
+const testIconId = 'test-icon';
+const testIcon = 'mail icon';
+const testSize = defaultState.size;
 
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
-
-    it('renders the component', () => {
-        ReactDOM.render(renderComponent({}), container);
-        const icon = container.querySelector('svg');
-        expect(icon).not.toBeNull();
-    });
-    it('renders correct SVG', () => {
-        ReactDOM.render(renderComponent({ svg: iconTypes.mail }), container);
-        const icon = container.querySelector('svg');
-        expect(icon?.textContent).toBe(testIcon);
-    });
-    xit('renders the correct size', () => {
-        ReactDOM.render(renderComponent({ size: testSize }), container);
-        const icon = container.querySelector('svg');
-        expect(icon?.clientHeight).toBe(testSize);
-        expect(icon?.clientWidth).toBe(testSize);
-    });
-    it('renders aria hidden attribute', () => {
-        ReactDOM.render(renderComponent({ size: testSize }), container);
-        const icon = container.querySelector('svg');
-        expect(icon?.getAttribute('aria-hidden')).toBe('true');
-    });
+test('Renders - Icon Default', () => {
+    render(renderComponent({}));
+    const iconElement = screen.getByTestId(testIconId);
+    expect(iconElement).not.toBeNull();
+    expect(iconElement.getAttribute('aria-hidden')).toBe('true');
 });
 
-describe('Icon - mapped', () => {
-    let container: HTMLDivElement;
+test('Renders - Icon with custom svg', () => {
+    render(renderComponent({ svg: iconTypes.mail }));
+    const iconElement = screen.getByTestId(testIconId);
+    expect(iconElement.textContent).toBe(testIcon);
+    expect(iconElement.getAttribute('aria-hidden')).toBe('true');
+});
 
-    beforeEach(() => {
-        container = document.createElement('div');
-        document.body.appendChild(container);
-    });
-    afterEach(() => {
-        document.body.removeChild(container);
-        container.remove();
-    });
+test('Renders - Icon with custom size', () => {
+    render(renderComponent({ size: testSize }));
+    const iconElement = screen.getByTestId(testIconId);
+    expect(iconElement.getAttribute('height')).toBe(testSize?.toString());
+    expect(iconElement.getAttribute('width')).toBe(testSize?.toString());
+    expect(iconElement.getAttribute('aria-hidden')).toBe('true');
+});
 
-    Object.keys(iconTypes).forEach((icon) => {
-        const svg = icon as TIconType;
-
-        it(`should render - ${icon}`, () => {
-            ReactDOM.render(renderComponent({ svg }), container);
-            const found = container.querySelector('svg');
-            expect(found).not.toBeNull();
-        });
+Object.keys(iconTypes).forEach((icon) => {
+    const svg = icon as TIconType;
+    test(`Renders - Icon ${svg}`, () => {
+        render(renderComponent({ svg }));
+        expect(screen.getByTestId(testIconId)).not.toBeNull();
     });
 });

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable linebreak-style */
 import React from 'react';
 import collection, { TIconType } from './collection';
-import { StyledIconDiv } from './Icon.styles';
+import styles from './Icon.styles';
 import type { IconProps } from './types';
+
+const { StyledIconDiv } = styles;
 
 const Icon: React.FC<IconProps> = ({
     fill = 'inherit',

--- a/src/components/Icon/icons/ada.tsx
+++ b/src/components/Icon/icons/ada.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const adaIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="Layer_2_1_"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/atomicApi.tsx
+++ b/src/components/Icon/icons/atomicApi.tsx
@@ -7,6 +7,8 @@ const atomicApiIcon = (
     style?: React.CSSProperties,
 ) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         width={size}
         height={size}
         viewBox="0 0 24 24"

--- a/src/components/Icon/icons/avax.tsx
+++ b/src/components/Icon/icons/avax.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const avaxIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size}

--- a/src/components/Icon/icons/bnb.tsx
+++ b/src/components/Icon/icons/bnb.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const bnbIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="Layer2"
         data-name="Layer2"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Icon/icons/btc.tsx
+++ b/src/components/Icon/icons/btc.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const btcIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size}

--- a/src/components/Icon/icons/chainlink.tsx
+++ b/src/components/Icon/icons/chainlink.tsx
@@ -7,6 +7,8 @@ const chainlinkIcon = (
     style?: React.CSSProperties,
 ) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="Layer_2"
         data-name="Layer 2"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Icon/icons/dapps.tsx
+++ b/src/components/Icon/icons/dapps.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const dappsIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         width={size}
         height={size}
         viewBox="0 0 24 24"

--- a/src/components/Icon/icons/doge.tsx
+++ b/src/components/Icon/icons/doge.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const dogeIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size}

--- a/src/components/Icon/icons/eth.tsx
+++ b/src/components/Icon/icons/eth.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const ethIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="Layer_x0020_1"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/fil.tsx
+++ b/src/components/Icon/icons/fil.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const filIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size}

--- a/src/components/Icon/icons/matic.tsx
+++ b/src/components/Icon/icons/matic.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const maticIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="polygon-matic-logo"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/metamask.tsx
+++ b/src/components/Icon/icons/metamask.tsx
@@ -7,6 +7,8 @@ const metamaskIcon = (
 ) => {
     return (
         <svg
+            aria-hidden="true"
+            data-testid="test-icon"
             width={size}
             height={size}
             viewBox="0 0 24 24"

--- a/src/components/Icon/icons/metamaskLined.tsx
+++ b/src/components/Icon/icons/metamaskLined.tsx
@@ -7,6 +7,8 @@ const metamaskLinedIcon = (
 ) => {
     return (
         <svg
+            aria-hidden="true"
+            data-testid="test-icon"
             width={size}
             height={size}
             viewBox="0 0 24 24"

--- a/src/components/Icon/icons/oneinch.tsx
+++ b/src/components/Icon/icons/oneinch.tsx
@@ -7,6 +7,8 @@ const oneinchIcon = (
     style?: React.CSSProperties,
 ) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size / 1.0605}

--- a/src/components/Icon/icons/shib.tsx
+++ b/src/components/Icon/icons/shib.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const shibIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="Group_938"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/speedyNode.tsx
+++ b/src/components/Icon/icons/speedyNode.tsx
@@ -7,6 +7,8 @@ const speedyNodeIcon = (
     style?: React.CSSProperties,
 ) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         width={size}
         height={size}
         viewBox="0 0 24 24"

--- a/src/components/Icon/icons/uni.tsx
+++ b/src/components/Icon/icons/uni.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const uniIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="uniswap-uni-logo"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/usdc.tsx
+++ b/src/components/Icon/icons/usdc.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const usdcIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="usdc"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/usdt.tsx
+++ b/src/components/Icon/icons/usdt.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const usdtIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         id="tether-usdt-logo"
         xmlns="http://www.w3.org/2000/svg"
         width={size}

--- a/src/components/Icon/icons/web3api.tsx
+++ b/src/components/Icon/icons/web3api.tsx
@@ -7,6 +7,8 @@ const web3apiIcon = (
     style?: React.CSSProperties,
 ) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         width={size}
         height={size}
         viewBox="0 0 24 24"

--- a/src/components/Icon/icons/xrp.tsx
+++ b/src/components/Icon/icons/xrp.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 const xrpIcon = (fill: string, size: number, style?: React.CSSProperties) => (
     <svg
+        aria-hidden="true"
+        data-testid="test-icon"
         xmlns="http://www.w3.org/2000/svg"
         width={size}
         height={size / 1.230769230769231}


### PR DESCRIPTION
- tests meet React18 standards
- all layouts / setups are rendered in stories
- scoped CSS without named exports
- added data-testid and aria-hidden attributes to many of the svg's.
closes #369 