### PR TITLE
[Fix] Text Area - Placeholder visible behind label

### DIFF
--- a/src/components/TextArea/TextArea.styles.ts
+++ b/src/components/TextArea/TextArea.styles.ts
@@ -93,8 +93,7 @@ const TextAreaStyled = styled.textarea<TStyleProps>`
     }
 
     &::placeholder {
-        visibility: hidden;
-        display: none;
+        opacity: 0;
     }
 
     &:focus,
@@ -110,8 +109,7 @@ const TextAreaStyled = styled.textarea<TStyleProps>`
 
     &:focus {
         &::placeholder {
-            display: none;
-            visibility: visible;
+            opacity: 1;
             color: ${color.grey};
         }
     }

--- a/src/components/TextArea/TextArea.styles.ts
+++ b/src/components/TextArea/TextArea.styles.ts
@@ -88,10 +88,6 @@ const TextAreaStyled = styled.textarea<TStyleProps>`
     padding: 2px;
     width: 100%;
 
-    ::-webkit-resizer {
-        visibility: hidden;
-    }
-
     &::placeholder {
         opacity: 0;
     }

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,7 +1,4 @@
 import React, { useState, useRef, useEffect } from 'react';
-import color from '../../styles/colors';
-import { Icon } from '../Icon';
-import { iconTypes } from '../Icon/collection';
 import styles from './TextArea.styles';
 import { TextAreaProps } from './types';
 
@@ -43,16 +40,6 @@ const TextArea: React.FC<TextAreaProps> = ({
             state={state}
             width={width}
         >
-            <Icon
-                svg={iconTypes.expand}
-                style={{
-                    bottom: '10px',
-                    position: 'absolute',
-                    right: '10px',
-                    zIndex: '-1',
-                }}
-                fill={color.blue}
-            />
             <TextAreaStyled
                 autoComplete={`${autoComplete}`}
                 data-testid="test-textarea"

--- a/src/components/TextArea/types.tsx
+++ b/src/components/TextArea/types.tsx
@@ -37,9 +37,10 @@ export interface TextAreaProps {
     state?: 'error' | 'confirmed' | 'disabled';
 
     /**
-     * types of input available
+     * You can validate your textarea
+     * characterMaxLength, characterMinLength, numberMax, numberMin, regExp, regExpInvalidMessage & required
      */
-    type?: 'text' | 'number' | 'email' | 'tel' | 'password';
+    validation?: ValidateInput;
 
     /**
      * you can pass a default value so the input is pre-filled
@@ -50,10 +51,4 @@ export interface TextAreaProps {
      * you can pass a CSS value for the components width
      */
     width?: string;
-
-    /**
-     * You can validate your textarea
-     * characterMaxLength, characterMinLength, numberMax, numberMin, regExp, regExpInvalidMessage & required
-     */
-    validation?: ValidateInput;
 }


### PR DESCRIPTION
Fixed issue on mozilla.
closes #457 

Removed type prop as it is unused. Let me know if this needs to be reverted.