### PR TITLE
feat(CodeArea): added disabled prop

### DIFF
--- a/src/components/CodeArea/CodeArea.tsx
+++ b/src/components/CodeArea/CodeArea.tsx
@@ -16,6 +16,7 @@ const CodeArea: FC<ICodeAreaProps> = ({
     maxWidth = '100%',
     onChange,
     headerComponent,
+    disabled,
 }) => {
     const [currentValue, setCurrentValue] = useState(text);
 
@@ -56,6 +57,7 @@ const CodeArea: FC<ICodeAreaProps> = ({
                         ) => valueChanged(event)}
                         spellCheck={false}
                         value={currentValue}
+                        disabled={disabled}
                     />
                 </ContentStyled>
             </WrapperStyled>

--- a/src/components/CodeArea/types.ts
+++ b/src/components/CodeArea/types.ts
@@ -19,6 +19,12 @@ export interface ICodeAreaProps {
      * please add the text you want to show in the codearea
      */
     text: string;
+
+    /**
+     * if true disabled editing of the text content
+     * standard prop for textarea
+     */
+    disabled?: boolean;
 }
 
 export interface ILineNumbersProps {


### PR DESCRIPTION
Standard HTML prop for `textarea` we use in the `<CodeArea />`

closes #474 