### PR TITLE
Fix:Credentials comp - Mobile screen text truncate

### DIFF
--- a/src/components/Credentials/Credentials.stories.tsx
+++ b/src/components/Credentials/Credentials.stories.tsx
@@ -46,3 +46,17 @@ WithCustomColors.args = {
     text: 'https://xj5hyiafwkhn.moralis.io:2053/servers',
     textColor: 'red',
 };
+
+export const Multiline = Template.bind({});
+Multiline.args = {
+    title: 'Multiline Text:',
+    hasHideButton: false,
+    text: `[common]
+    dapp_addr = onfkgi4pc9ld.moralis.io
+    dapp_port = 7000
+    token = KKKaDjYz0i
+[Ganache]
+    type = http
+    local_port = 8545
+    custom_domains = onfkgi4pc9ld.moralis.io`,
+};

--- a/src/components/Credentials/Credentials.styles.tsx
+++ b/src/components/Credentials/Credentials.styles.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import color from '../../styles/colors';
 import resetCSS from '../../styles/reset';
-import { ICredentialsProps } from './types';
+import { ICredentialsProps, TDivWrapper } from './types';
 
 const CredentialsStyled = styled.div<Pick<ICredentialsProps, 'width'>>`
     background: ${color.blueLight};
@@ -41,15 +41,15 @@ const DividerStyled = styled.div`
     }
 `;
 
-const DivWrapper = styled.div<Pick<ICredentialsProps, 'isHidden'>>`
+const DivWrapperStyled = styled.div<TDivWrapper>`
     ${resetCSS};
-    overflow-x: ${(p) => p.isHidden && 'hidden'};
+    overflow-x: ${(p) => (p.isHidden ? 'hidden' : p.isMultiline && 'auto')};
     width: 90%;
 `;
 
 export default {
     CredentialsStyled,
-    DivWrapper,
+    DivWrapperStyled,
     DividerStyled,
     PreformattedStyled,
     ToolsStyled,

--- a/src/components/Credentials/Credentials.styles.tsx
+++ b/src/components/Credentials/Credentials.styles.tsx
@@ -19,7 +19,6 @@ const PreformattedStyled = styled.pre`
     display: flex;
     height: max-content;
     justify-content: space-between;
-    overflow-x: auto;
     position: relative;
 `;
 
@@ -42,8 +41,15 @@ const DividerStyled = styled.div`
     }
 `;
 
+const DivWrapper = styled.div<Pick<ICredentialsProps, 'isHidden'>>`
+    ${resetCSS};
+    overflow-x: ${(p) => p.isHidden && 'hidden'};
+    width: 90%;
+`;
+
 export default {
     CredentialsStyled,
+    DivWrapper,
     DividerStyled,
     PreformattedStyled,
     ToolsStyled,

--- a/src/components/Credentials/Credentials.tsx
+++ b/src/components/Credentials/Credentials.tsx
@@ -11,7 +11,7 @@ import TruncateString from './components/TruncateString';
 const {
     CredentialsStyled,
     DividerStyled,
-    DivWrapper,
+    DivWrapperStyled,
     PreformattedStyled,
     ToolsStyled,
 } = styles;
@@ -31,8 +31,16 @@ const Credentials: FC<ICredentialsProps> = ({
     hiddenText = '•••••••••••••••••••••••••••••••',
 }) => {
     const [isValueHidden, setIsValueHidden] = useState(isHidden);
+    const [isMultiline, setIsMultiline] = useState(
+        (text.match(/\n/g) || []).length > 0,
+    );
 
     useEffect(() => setIsValueHidden(isHidden), [isHidden]);
+
+    useEffect(
+        () => setIsMultiline((text.match(/\n/g) || []).length > 0),
+        [text],
+    );
 
     return (
         <CredentialsStyled width={width} data-testid="test-credentials">
@@ -44,7 +52,10 @@ const Credentials: FC<ICredentialsProps> = ({
                 iconSize={iconSize}
             />
             <PreformattedStyled>
-                <DivWrapper isHidden={isValueHidden}>
+                <DivWrapperStyled
+                    isHidden={isValueHidden}
+                    isMultiline={isMultiline}
+                >
                     <Typography
                         monospace
                         color={textColor}
@@ -52,6 +63,8 @@ const Credentials: FC<ICredentialsProps> = ({
                     >
                         {isValueHidden ? (
                             hiddenText
+                        ) : isMultiline ? ( // Multiline text will be shown with scrollbar
+                            text
                         ) : (
                             <TruncateString
                                 text={text}
@@ -59,7 +72,7 @@ const Credentials: FC<ICredentialsProps> = ({
                             />
                         )}
                     </Typography>
-                </DivWrapper>
+                </DivWrapperStyled>
                 <ToolsStyled>
                     {hasHideButton && (
                         <HideButton

--- a/src/components/Credentials/Credentials.tsx
+++ b/src/components/Credentials/Credentials.tsx
@@ -6,9 +6,15 @@ import { ICredentialsProps } from './types';
 import CredentialsHeader from './components/CredentialsHeader';
 import { HideButton } from '../HideButton';
 import { CopyButton } from '../CopyButton';
+import TruncateString from './components/TruncateString';
 
-const { CredentialsStyled, DividerStyled, PreformattedStyled, ToolsStyled } =
-    styles;
+const {
+    CredentialsStyled,
+    DividerStyled,
+    DivWrapper,
+    PreformattedStyled,
+    ToolsStyled,
+} = styles;
 
 const Credentials: FC<ICredentialsProps> = ({
     hasCopyButton = true,
@@ -38,13 +44,22 @@ const Credentials: FC<ICredentialsProps> = ({
                 iconSize={iconSize}
             />
             <PreformattedStyled>
-                <Typography
-                    monospace
-                    color={textColor}
-                    data-testid="cred-test-text"
-                >
-                    {isValueHidden ? hiddenText : text}
-                </Typography>
+                <DivWrapper isHidden={isValueHidden}>
+                    <Typography
+                        monospace
+                        color={textColor}
+                        data-testid="cred-test-text"
+                    >
+                        {isValueHidden ? (
+                            hiddenText
+                        ) : (
+                            <TruncateString
+                                text={text}
+                                percentageOfCharsAfterTrunc={55}
+                            />
+                        )}
+                    </Typography>
+                </DivWrapper>
                 <ToolsStyled>
                     {hasHideButton && (
                         <HideButton

--- a/src/components/Credentials/components/TruncateString.tsx
+++ b/src/components/Credentials/components/TruncateString.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect } from 'react';
+import { FC, useRef, useState } from 'react';
+import { ITruncateStringProps, TStringTruncate } from '../types';
+
+const truncateString = ({
+    leftPercentage = 50,
+    measurements,
+    replaceString,
+    text,
+}: TStringTruncate): string => {
+    if (
+        measurements.text &&
+        measurements.component &&
+        measurements.text > measurements.component
+    ) {
+        const size = (percentage: number) =>
+            measurements.component * (percentage / 100);
+        const portion = (size: number) =>
+            Math.floor((text.length * size) / measurements.text);
+
+        const leftPart = text.slice(
+            0,
+            Math.max(0, portion(size(leftPercentage)) - replaceString.length),
+        );
+
+        const rightPart = text.slice(
+            text.length -
+                portion(size(100 - leftPercentage)) +
+                replaceString.length,
+            text.length,
+        );
+
+        return `${leftPart}${replaceString}${rightPart}`;
+    } else {
+        return text;
+    }
+};
+
+const TruncateString: FC<ITruncateStringProps> = ({
+    replaceString = '...',
+    percentageOfCharsAfterTrunc = 50,
+    text = '',
+}) => {
+    const [truncating, setTruncating] = useState(true);
+    const [truncatedString, setTruncatedString] = useState<string | null>(null);
+    const componentRef = useRef<HTMLDivElement>(null);
+    const textRef = useRef<HTMLSpanElement>(null);
+    const replaceStrRef = useRef<HTMLSpanElement>(null);
+
+    const getTruncatedString = (text: string) => {
+        const measurements = {
+            component: componentRef.current?.offsetWidth || 0,
+            replace: replaceStrRef.current?.offsetWidth || 0,
+            text: textRef.current?.offsetWidth || 0,
+        };
+        return truncateString({
+            leftPercentage: percentageOfCharsAfterTrunc,
+            measurements,
+            replaceString,
+            text,
+        });
+    };
+
+    useEffect(() => {
+        // 2. Call Truncating function on every state change
+        if (truncating) {
+            const ts = getTruncatedString(text);
+            setTruncatedString(ts);
+            setTruncating(false);
+        }
+    }, [truncating]);
+
+    useEffect(() => {
+        // Debounce Mechanism
+        let timeoutId: any = null;
+        const truncateListener = () => {
+            clearTimeout(timeoutId);
+            // 1. Resizing window sets Truncating state to True
+            timeoutId = setTimeout(() => setTruncating(true), 50);
+        };
+        window.addEventListener('resize', truncateListener);
+
+        // Remove listener on component unmount
+        return () => {
+            window.removeEventListener('resize', truncateListener);
+        };
+    }, []);
+
+    return (
+        <div
+            ref={componentRef}
+            style={{
+                display: 'block',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+            }}
+        >
+            {truncating && <span ref={textRef}>{text}</span>}
+            {truncating && <span ref={replaceStrRef}>{replaceString}</span>}
+            {!truncating && truncatedString}
+        </div>
+    );
+};
+
+export default TruncateString;

--- a/src/components/Credentials/types.ts
+++ b/src/components/Credentials/types.ts
@@ -66,3 +66,50 @@ export interface ICredentialsHeaderProps {
      */
     iconSize?: number;
 }
+
+export interface ITruncateStringProps {
+    /**
+     * String to replace the truncated section
+     */
+    replaceString?: string;
+    /**
+     * String to Truncate according to screen width
+     */
+    text: string;
+    /**
+     * Percentage of characters(approx) to remain after truncate
+     */
+    percentageOfCharsAfterTrunc?: number;
+}
+
+export type TStringTruncate = {
+    /**
+     * Text to truncate
+     */
+    text: string;
+    /**
+     * String to replace the truncated section
+     */
+    replaceString: string;
+    /**
+     * to store widths for calculating if text should be truncated or not
+     */
+    measurements: {
+        /**
+         * Width of text component
+         */
+        text: number;
+        /**
+         * Width of parent component (which contains text)
+         */
+        component: number;
+        /**
+         * Width of replace string component
+         */
+        replace: number;
+    };
+    /**
+     * Percentage of characters from that should remain after truncate (approx)
+     */
+    leftPercentage: number;
+};

--- a/src/components/Credentials/types.ts
+++ b/src/components/Credentials/types.ts
@@ -113,3 +113,15 @@ export type TStringTruncate = {
      */
     leftPercentage: number;
 };
+
+export type TDivWrapper = {
+    /**
+     * text is hidden
+     */
+    isHidden: boolean;
+
+    /**
+     * text is multiline
+     */
+    isMultiline: boolean;
+};


### PR DESCRIPTION
Things done:

- Fixed the overflow error.
- Truncate text on smaller screen
- Made this truncate text component as reusable as possible - (Let me know if it needs to be moved to a different folder)  

![credentials](https://user-images.githubusercontent.com/35369843/164903277-dde5f1d2-1eb4-4bda-b9d9-056d29237a14.gif)

closes #454 