### PR TITLE
feat(ToolTip): added move and moveBody props

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -11,16 +11,18 @@ import color from '../../styles/colors';
 const { AbsoluteIconStyled, DivStyled, FooterStyled, HeaderStyled } = styles;
 
 const Card: React.FC<CardProps> = ({
-    id,
     children,
     cursorType = 'pointer',
     description,
-    isSelected,
-    title,
-    tooltipText,
+    id,
     isDisabled = false,
-    setIsSelected,
+    isSelected,
     onClick,
+    setIsSelected,
+    title,
+    tooltipMove,
+    tooltipMoveBody,
+    tooltipText,
 }: CardProps) => {
     return (
         <DivStyled
@@ -63,6 +65,8 @@ const Card: React.FC<CardProps> = ({
                                 />,
                             ]}
                             content={tooltipText}
+                            move={tooltipMove}
+                            moveBody={tooltipMoveBody}
                         />
                     </AbsoluteIconStyled>
                 )}

--- a/src/components/Card/types.ts
+++ b/src/components/Card/types.ts
@@ -50,6 +50,16 @@ export interface CardProps {
      * Runs a function when clicked
      */
     onClick?: () => void;
+
+    /**
+     * Moves the tooltip arrow +/- up/down/left/right (use responsibly, arrow can move the the X / Y axis indefinitely)
+     */
+    tooltipMove?: number;
+
+    /**
+     * Moves the tooltip body +/- up/down/left/right (use responsibly, arrow can move the the X / Y axis indefinitely)
+     */
+    tooltipMoveBody?: number;
 }
 
 export interface AbsoluteIconStyledProps {

--- a/src/components/Tooltip/Tooltip.styles.ts
+++ b/src/components/Tooltip/Tooltip.styles.ts
@@ -11,86 +11,79 @@ interface IStyledHoverSpan {
     position: Position;
     width: number;
     minWidth: number;
+    moveBody: number;
 }
+
+const defaultTriangleStyle = css`
+    position: absolute;
+    height: 0;
+    width: 0;
+`;
+
+type TTooltipPositioningProps = Pick<TooltipProps, 'move' | 'moveBody'>;
 
 // Left Position comps
 const leftPositionPopover = css<IStyledHoverSpan>`
     right: ${(props) => props.width && `calc(${props.width}px + 10px)`};
-    top: 0px;
-    ${(props) => {
-        return `transform: translateY(-${
-            (props.popoverHeight - props.height) / 2
-        }px)`;
-    }}
+    top: 50%;
+    transform: translateY(${(p) => `${p.moveBody}%`});
 `;
 
-const leftPositionTriangle = css`
+const leftPositionTriangle = css<TTooltipPositioningProps>`
+    ${defaultTriangleStyle};
     border-bottom: 10px solid transparent;
     border-left: 10px solid ${color.blueDark2};
     border-top: 10px solid transparent;
-    height: 0;
-    position: absolute;
     right: -10px;
-    top: calc(50% - 10px);
-    width: 0;
+    top: calc(${(p) => `${p.move}%`} - 10px);
 `;
 
 // Right position comps
 const rightPositionPopover = css<IStyledHoverSpan>`
     left: ${(props) => props.width && `calc(${props.width}px + 10px)`};
-    top: 0px;
-    ${(props) => {
-        return `transform: translateY(-${
-            (props.popoverHeight - props.height) / 2
-        }px)`;
-    }}}
+    top: 50%;
+    transform: translateY(${(p) => `${p.moveBody}%`});
 `;
 
-const rightPositionTriangle = css`
+const rightPositionTriangle = css<TTooltipPositioningProps>`
+    ${defaultTriangleStyle};
     border-bottom: 10px solid transparent;
     border-right: 10px solid ${color.blueDark2};
     border-top: 10px solid transparent;
-    height: 0;
     left: -10px;
-    position: absolute;
-    top: calc(50% - 10px);
-    width: 0;
+    top: calc(${(p) => `${p.move}%`} - 10px);
 `;
 
 // Top Position Comps
 const topPositionPopover = css<IStyledHoverSpan>`
     bottom: ${(props) => props.height && `calc(${props.height}px + 10px)`};
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(${(p) => `${p.moveBody}%`});
 `;
 
-const topPositionTriangle = css`
+const topPositionTriangle = css<TTooltipPositioningProps>`
+    ${defaultTriangleStyle};
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
     border-top: 10px solid ${color.blueDark2};
-    height: 0;
-    left: calc(50% - 10px);
-    position: absolute;
+    left: calc(${(p) => `${p.move}%`} - 10px);
     top: 100%;
-    width: 0;
 `;
 
 // bottom Position Comps
 const bottomPositionPopover = css<IStyledHoverSpan>`
     left: 50%;
     top: ${(props) => props.height && `calc(${props.height}px + 10px)`};
-    transform: translateX(-50%);
+    transform: translateX(${(p) => `${p.moveBody}%`});
 `;
 
-const bottomPositionTriangle = css`
+const bottomPositionTriangle = css<TTooltipPositioningProps>`
+    ${defaultTriangleStyle}
     border-bottom: 10px solid ${color.blueDark2};
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
-    height: 0;
-    left: calc(50% - 10px);
-    position: absolute;
+    left: calc(${(p) => `${p.move}%`} - 10px);
     top: -10px;
-    width: 0;
 `;
 
 const getTriangleComp = {
@@ -143,7 +136,7 @@ const DivStyledTooltipText = styled.div<
 `;
 
 export const DivStyledArrow = styled.div<
-    Pick<TooltipProps, 'position'>
+    Pick<TooltipProps, 'position' | 'move' | 'moveBody'>
 >`
     ${({ position }) => getTriangleComp[position]}
 `;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,6 +14,8 @@ const Tooltip: React.FC<TooltipProps> = ({
     content,
     maxWidth,
     minWidth,
+    move = 50,
+    moveBody = -50,
     position = 'bottom',
 }: TooltipProps) => {
     const parentRef = useRef(null);
@@ -53,14 +55,12 @@ const Tooltip: React.FC<TooltipProps> = ({
                 minWidth={minWidth as number}
                 position={position}
                 data-testid={'tooltip-children-test-id'}
+                moveBody={moveBody}
             >
-                <DivStyledTooltipText
-                    maxWidth={maxWidth}
-                    minWidth={minWidth}
-                >
+                <DivStyledTooltipText maxWidth={maxWidth} minWidth={minWidth}>
                     {content}
                 </DivStyledTooltipText>
-                <DivStyledArrow position={position} />
+                <DivStyledArrow position={position} move={move} />
             </DivStyled>
         </DivStyledTooltipParent>
     );

--- a/src/components/Tooltip/types.ts
+++ b/src/components/Tooltip/types.ts
@@ -25,4 +25,14 @@ export interface TooltipProps {
      * Set the min width of the tooltip
      */
     minWidth?: number;
+
+    /**
+     * Moves the arrow +/- up/down/left/right (use responsibly, arrow can move the the X / Y axis indefinitely)
+     */
+    move?: number;
+
+    /**
+     * Moves the body +/- up/down/left/right (use responsibly, arrow can move the the X / Y axis indefinitely)
+     */
+    moveBody?: number;
 }


### PR DESCRIPTION

- added `move` and `moveBody` properties for the `Tooltip` component (same as for `Popover`)
- updated props for Card 

![image](https://user-images.githubusercontent.com/78314301/165030351-df666d5f-52aa-44ba-b3cd-2709ef0bb5e8.png)


closes #481 