### PR TITLE
fix: Select use same padding as SelectedOption for Option

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -150,12 +150,14 @@ export const PrefixIcon = Template.bind({});
 PrefixIcon.args = {
     options: [
         {
-            label: 'All',
-            id: 'All',
+            label: 'Mainnet',
+            id: 'Mainnet',
+            prefix: <Icon svg={iconTypes.server} fill={color.grey} />,
         },
         {
-            label: 'Active',
-            id: 'Active',
+            label: 'Testnet',
+            id: 'Testnet',
+            prefix: <Icon svg={iconTypes.testnet} fill={color.grey} />,
         },
     ],
     onChange: onTestOptionChange,

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -151,17 +151,23 @@ PrefixIcon.args = {
     options: [
         {
             label: 'Mainnet',
-            id: 'Mainnet',
+            id: 'Testnet',
             prefix: <Icon svg={iconTypes.server} fill={color.grey} />,
         },
         {
-            label: 'Testnet',
+            label: 'Mainnet',
             id: 'Testnet',
             prefix: <Icon svg={iconTypes.testnet} fill={color.grey} />,
+        },
+        {
+            label: 'Local Dev Chain',
+            id: 'LocalDevChain',
+            prefix: <Icon svg={iconTypes.btc} fill={color.grey} />,
         },
     ],
     onChange: onTestOptionChange,
     prefixIcon: 'server',
+    width: '100%',
     label: 'Select Server',
 };
 

--- a/src/components/Select/Select.styles.ts
+++ b/src/components/Select/Select.styles.ts
@@ -56,7 +56,7 @@ const SelectedItem = styled.div<SelectedItemProps>`
         }
     }};
 
-    ${({ hasPrefixIcon }) => hasPrefixIcon && 'gap: 15px'};
+    ${({ hasPrefixIcon }) => hasPrefixIcon && 'gap: 13px'};
 
     ${({ state }) =>
         state === 'disabled' &&
@@ -111,7 +111,6 @@ const SelectedItem = styled.div<SelectedItemProps>`
 const iconStyle = css`
     align-items: center;
     display: flex;
-    height: 100%;
     justify-content: center;
     max-height: 24px;
     max-width: 24px;
@@ -121,7 +120,7 @@ const iconStyle = css`
 const PrefixIcon = styled.div`
     ${resetCSS}
     ${iconStyle}
-    margin-right: 8px;
+    margin-right: 13px;
     & :first-child {
         width: 100%;
         height: 100%;

--- a/src/components/Select/Select.styles.ts
+++ b/src/components/Select/Select.styles.ts
@@ -1,8 +1,8 @@
-import styled, { css } from 'styled-components';
+import { LabelProps, SelectedItemProps, SelectProps } from './types';
 import color from '../../styles/colors';
 import fonts from '../../styles/fonts';
 import resetCSS from '../../styles/reset';
-import { LabelProps, SelectedItemProps, SelectProps } from './types';
+import styled, { css } from 'styled-components';
 
 const DivStyledWrapper = styled.div<Pick<SelectProps, 'state'>>`
     ${resetCSS};
@@ -185,7 +185,7 @@ const Option = styled.div`
     align-items: center;
     cursor: pointer;
     display: flex;
-    padding: 13px 20px;
+    padding: 14px 50px 14px 16px;
     &:hover {
         background-color: rgba(128, 128, 128, 0.1);
     }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/60792849/165916571-90906a7e-db59-4d9b-a8ae-a096493746c7.png)


Now:
![Screenshot 2022-04-29 at 11 11 50](https://user-images.githubusercontent.com/60792849/165916613-643cbcac-a8ec-4a09-b996-7579030d6150.png)

