### PR TITLE
Table overflow and Chain Selector

### DIFF
--- a/src/components/ChainSelector/ChainSelector.tsx
+++ b/src/components/ChainSelector/ChainSelector.tsx
@@ -33,9 +33,11 @@ const ChainSelector: FC<IChainSelectorProps> = ({
 
     const toggleEvm = (chain: string) => {
         if (values.map((x) => x.chainId).includes(chain)) {
+            // toggling same element
             const newArray = values.filter((e) => e.chainId !== chain);
             setValue(newArray);
-        } else {
+        } else if (IsMultipleAllowed) {
+            // adding if multiple elements are allowed
             const newArray = [
                 ...values,
                 {
@@ -45,6 +47,15 @@ const ChainSelector: FC<IChainSelectorProps> = ({
                 },
             ];
             setValue(newArray);
+        } else {
+            // one card selection case
+            setValue([
+                {
+                    chainId: chain,
+                    maxRecordsPerCategory: 50,
+                    userSync: true,
+                },
+            ]);
         }
     };
 

--- a/src/components/Table/Table.styles.ts
+++ b/src/components/Table/Table.styles.ts
@@ -31,8 +31,8 @@ export const Divider = styled.div`
     padding-top: 1px;
     background: radial-gradient(
         106.45% 108.64% at 32.33% -4.84%,
-        #ECF5FC 0.52%,
-        #CEE4F3 100%
+        #ecf5fc 0.52%,
+        #cee4f3 100%
     );
     grid-column: 1 / -1;
 `;
@@ -95,7 +95,7 @@ export const TableGrid = styled.div.attrs((props: any) => ({
     & > div.table_header {
         font-weight: 600;
         padding: 12px 0;
-    
+
         &:first-of-type {
             padding-left: 22px;
         }
@@ -105,13 +105,18 @@ export const TableGrid = styled.div.attrs((props: any) => ({
 export const TableGridContainer = styled.div`
     background: radial-gradient(
         106.45% 108.64% at 32.33% -4.84%,
-        #ECF5FC 0.52%,
-        #CEE4F3 100%
+        #ecf5fc 0.52%,
+        #cee4f3 100%
     );
     border-radius: 20px;
     padding: 1px;
     position: relative;
-    overflow: hidden;
+    overflow-x: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
 `;
 
 interface PaginationTag {

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -34,7 +34,7 @@ export const StyledTabBar = styled.div<IStyledTabBar>`
     display: flex;
     ${(props) => props.isVertical && 'flex-direction: column;'}
     max-width: fit-content;
-    height: 40px;
+    max-height: fit-content;
     ${(props) =>
         props.haveBackground &&
         `


### PR DESCRIPTION
Closes #530 
Table scrolling in mobile view instead of screen overflow. 
scrollbar is hidden - since in mobile view user uses touch input to scroll instead of scrollbar
![tableoverflow](https://user-images.githubusercontent.com/35369843/166007355-4491309f-596c-4591-8e5e-3b3b01d538fe.gif)

closes #529 
if IsMultipleAllowed is false then only single item can be selected (For admin syncs user wallet)
![chainselect](https://user-images.githubusercontent.com/35369843/166007624-2a6a9092-1bf3-42bd-b9cb-f47a7ac38ce7.gif)

closes #523 