### PR TITLE
Fix modal v scroll

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -11,9 +11,17 @@ import Dropdown from '../Dropdown/Dropdown';
 import { Typography } from '../Typography';
 import color from '../../styles/colors';
 
+const hasPositionAbsoluteFix = {
+    transform: 'scale(1)',
+    height: '90vh',
+};
+
 export default {
     title: '5.Popup/Modal',
     component: Modal,
+    decorators: [
+        (storyFn) => <div style={hasPositionAbsoluteFix}>{storyFn()}</div>,
+    ],
 } as ComponentMeta<typeof Modal>;
 
 const Template: ComponentStory<typeof Modal> = (args) => {

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -11,38 +11,32 @@ import Dropdown from '../Dropdown/Dropdown';
 import { Typography } from '../Typography';
 import color from '../../styles/colors';
 
-const hasPositionAbsoluteFix = {
-    transform: 'scale(1)',
-    height: '90vh',
-};
-
 export default {
     title: '5.Popup/Modal',
     component: Modal,
-    decorators: [
-        (storyFn) => <div style={hasPositionAbsoluteFix}>{storyFn()}</div>,
-    ],
 } as ComponentMeta<typeof Modal>;
 
 const Template: ComponentStory<typeof Modal> = (args) => {
     const [{}, updateArgs] = useArgs();
 
     return (
-        <Modal
-            {...args}
-            onCancel={() => {
-                console.log('canceled');
-                updateArgs({ isVisible: false });
-            }}
-            onOk={() => {
-                console.log('pressed ok');
-                updateArgs({ isVisible: false });
-            }}
-            onCloseButtonPressed={() => {
-                console.log('pressed close');
-                updateArgs({ isVisible: false });
-            }}
-        />
+        <div>
+            <Modal
+                {...args}
+                onCancel={() => {
+                    console.log('canceled');
+                    updateArgs({ isVisible: false });
+                }}
+                onOk={() => {
+                    console.log('pressed ok');
+                    updateArgs({ isVisible: false });
+                }}
+                onCloseButtonPressed={() => {
+                    console.log('pressed close');
+                    updateArgs({ isVisible: false });
+                }}
+            />
+        </div>
     );
 };
 
@@ -63,6 +57,23 @@ Regular.args = {
     children: [<Input key={0} label="Nickname" width="100%" />],
 };
 
+export const VerticalCenter = Template.bind({});
+VerticalCenter.args = {
+    id: 'v-center',
+    title: (
+        <div style={{ display: 'flex', gap: 10 }}>
+            <Icon svg={iconTypes.edit} size={28} fill={colors.grey} />
+            <Typography variant="h3" color={color.grey}>
+                Edit Nickname
+            </Typography>
+        </div>
+    ),
+    okText: 'Save Changes',
+    cancelText: 'Discard Changes',
+    isCentered: true,
+    isVisible: true,
+    children: [<Input key={0} label="Nickname" width="100%" />],
+};
 export const BorderedHeader = Template.bind({});
 BorderedHeader.args = {
     id: 'regular',

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -5,7 +5,12 @@ import { ModalProps } from './types';
 
 type TStyleProps = Pick<
     ModalProps,
-    'isVisible' | 'hasCancel' | 'width' | 'canOverflow' | 'fixedMode'
+    | 'canOverflow'
+    | 'fixedMode'
+    | 'hasCancel'
+    | 'isCentered'
+    | 'isVisible'
+    | 'width'
 >;
 
 const overflow = (): string => {
@@ -24,7 +29,7 @@ const DivStyledWrap = styled.div<TStyleProps>`
     background-color: ${colors.white};
     border-radius: 20px;
     box-shadow: 0 4px 10px rgba(48, 71, 105, 0.1);
-    margin: auto;
+    margin: 80px auto;
     max-width: ${(p) => p.width};
     width: 96%;
     ${(p) => !p.canOverflow && overflow()}
@@ -92,10 +97,10 @@ const FooterStyled = styled.footer<TStyleProps>`
 `;
 
 const DivStyled = styled.div<TStyleProps>`
-    ${(p) => (p.isVisible ? 'display: flex;' : 'display: none;')};
-    align-items: flex-start;
+    align-items: ${({ isCentered }) => (isCentered ? ' center' : 'flex-start')};
     background: rgba(0, 0, 0, 0.3);
     bottom: 0;
+    display: ${({ isVisible }) => (isVisible ? ' flex' : 'none')};
     height: 100vh;
     justify-content: center;
     left: 0;

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -24,12 +24,8 @@ const DivStyledWrap = styled.div<TStyleProps>`
     background-color: ${colors.white};
     border-radius: 20px;
     box-shadow: 0 4px 10px rgba(48, 71, 105, 0.1);
-    left: 50%;
-    max-height: 98%;
+    margin: auto;
     max-width: ${(p) => p.width};
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
     width: 96%;
     ${(p) => !p.canOverflow && overflow()}
 `;
@@ -96,10 +92,14 @@ const FooterStyled = styled.footer<TStyleProps>`
 `;
 
 const DivStyled = styled.div<TStyleProps>`
-    ${(p) => (p.isVisible ? 'display: grid;' : 'display: none;')};
+    ${(p) => (p.isVisible ? 'display: flex;' : 'display: none;')};
+    align-items: flex-start;
     background: rgba(0, 0, 0, 0.3);
     bottom: 0;
+    height: 100vh;
+    justify-content: center;
     left: 0;
+    overflow: auto;
     position: fixed;
     right: 0;
     top: 0;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -22,6 +22,7 @@ const Modal: React.FC<ModalProps> = ({
     hasFooter = true,
     id = String(Date.now()),
     isCancelDisabled,
+    isCentered = false,
     isOkDisabled,
     isVisible = true,
     okText = 'Ok',
@@ -56,7 +57,12 @@ const Modal: React.FC<ModalProps> = ({
     };
 
     return (
-        <DivStyled id={id} isVisible={visible} data-testid="modal-test-id">
+        <DivStyled
+            data-testid="modal-test-id"
+            id={id}
+            isCentered={isCentered}
+            isVisible={visible}
+        >
             <DivStyledWrap width={width} canOverflow={canOverflow}>
                 <HeaderStyled
                     data-testid={'modal-header-test-id'}

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -43,6 +43,11 @@ export interface ModalProps {
     isCancelDisabled?: boolean;
 
     /**
+     * center the vertically in the screen
+     */
+    isCentered?: boolean;
+
+    /**
      * set if 'Ok' button is disabled
      */
     isOkDisabled?: boolean;


### PR DESCRIPTION
Fix #510 
- Fixed the vertical scrolling for big content modal so it scrolls outside the modal not inside

https://user-images.githubusercontent.com/13832392/166104665-5d7b6dd1-d8b5-4f7d-9c87-8892e00831b1.mp4


- I realized that there are some modals that are not vertical centered and others with vertical center like this modal
![image](https://user-images.githubusercontent.com/13832392/166104487-0e0b77e7-ed78-4424-ab5a-d06941656c97.png)

So I added `isCentered` props to center the modal vertically on demand 



