### PR TITLE
feat: description for select comp

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -204,3 +204,23 @@ HTML5Select.args = {
     validation: { required: true },
     value: 'txt',
 };
+
+export const HTML5SelectWithDescription = Template.bind({});
+HTML5SelectWithDescription.args = {
+    description: 'Much Needed',
+    label: 'Good old HTML5',
+    onChangeTraditional: onTestOptionChange,
+    options: smallOptionsList,
+    traditionalHTML5: true,
+    validation: { required: true },
+    value: 'txt',
+};
+
+export const Description = Template.bind({});
+Description.args = {
+    options: smallOptionsList,
+    onChange: onTestOptionChange,
+    label: 'Label Text',
+    defaultOptionIndex: 0,
+    description: 'Much Needed',
+};

--- a/src/components/Select/Select.styles.ts
+++ b/src/components/Select/Select.styles.ts
@@ -204,7 +204,7 @@ const NoDataTextStyled = styled.p`
     margin-bottom: 5px;
 `;
 
-export const SelectStyled = styled.select`
+const SelectStyled = styled.select`
     ${resetCSS}
     ${fonts.text}
     background-color: transparent;
@@ -225,6 +225,22 @@ export const SelectStyled = styled.select`
     }
 `;
 
+const DivStyledDescription = styled.div`
+    ${resetCSS}
+    ${fonts.text}
+    bottom: -23px;
+    color: ${color.grey};
+    font-size: 12px;
+    height: 24px;
+    left: 16px;
+    overflow: hidden;
+    pointer-events: none;
+    position: absolute;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: calc(100% - 26px);
+`;
+
 export default {
     DivStyledWrapper,
     DropDownIcon,
@@ -237,4 +253,5 @@ export default {
     PrefixSpan,
     SelectStyled,
     SelectedItem,
+    DivStyledDescription,
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -9,6 +9,7 @@ const { DivWrapperStyled, LabelStyled: LabelStyledTrad } = InputStyles;
 
 const {
     DivStyledWrapper,
+    DivStyledDescription,
     DropDownIcon,
     ErrorLabel,
     LabelStyled,
@@ -24,6 +25,7 @@ const {
 const Select: React.FC<SelectProps> = ({
     customNoDataText = 'No Data',
     defaultOptionIndex,
+    description,
     disabled = false,
     errorMessage = '',
     id = String(Date.now()),
@@ -179,7 +181,13 @@ const Select: React.FC<SelectProps> = ({
                 </Options>
             )}
 
-            {errorMessage && <ErrorLabel>{errorMessage}</ErrorLabel>}
+            {state === 'error' && errorMessage ? (
+                <ErrorLabel>{errorMessage}</ErrorLabel>
+            ) : (
+                description && (
+                    <DivStyledDescription>{description}</DivStyledDescription>
+                )
+            )}
         </DivStyledWrapper>
     );
 
@@ -207,6 +215,9 @@ const Select: React.FC<SelectProps> = ({
                 <LabelStyledTrad hasPrefix={false} htmlFor={id}>
                     {label}
                 </LabelStyledTrad>
+            )}
+            {description && (
+                <DivStyledDescription>{description}</DivStyledDescription>
             )}
         </DivWrapperStyled>
     );

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -88,6 +88,11 @@ export interface SelectProps {
      * You can validate your inputs
      */
     validation?: { required: boolean };
+
+    /**
+     * Optional description under select component
+     */
+    description?: string;
 }
 
 export interface OptionProps {


### PR DESCRIPTION
Description below select component. for both Traditional HTML5 and default. 
For default if state=error and errorMessage is present error message would be shown else description message.

![image](https://user-images.githubusercontent.com/35369843/166508259-22c1d2c1-5ea3-4a6c-904c-3184d1b0cf7e.png)

closes #549 