### PR TITLE
fixed credentials styles

### DIFF
--- a/src/components/Credentials/Credentials.tsx
+++ b/src/components/Credentials/Credentials.tsx
@@ -28,8 +28,7 @@ const Credentials: FC<ICredentialsProps> = ({
     text,
     textColor = color.blueDark,
     width = 'auto',
-    hiddenText = '••• ••• ••• •••',
-    // hiddenText = '•••• •••• •••• ••••',
+    hiddenText = '•••••••••••••••••••••••••••••••',
 }) => {
     const [isValueHidden, setIsValueHidden] = useState(isHidden);
     const [isMultiline, setIsMultiline] = useState(

--- a/src/components/Credentials/Credentials.tsx
+++ b/src/components/Credentials/Credentials.tsx
@@ -28,7 +28,8 @@ const Credentials: FC<ICredentialsProps> = ({
     text,
     textColor = color.blueDark,
     width = 'auto',
-    hiddenText = '•••••••••••••••••••••••••••••••',
+    hiddenText = '••• ••• ••• •••',
+    // hiddenText = '•••• •••• •••• ••••',
 }) => {
     const [isValueHidden, setIsValueHidden] = useState(isHidden);
     const [isMultiline, setIsMultiline] = useState(
@@ -58,8 +59,10 @@ const Credentials: FC<ICredentialsProps> = ({
                 >
                     <Typography
                         monospace
-                        color={textColor}
+                        color={isValueHidden ? color.grey : textColor}
                         data-testid="cred-test-text"
+                        weight="400"
+                        variant={isValueHidden ? 'caption14' : 'body16'}
                     >
                         {isValueHidden ? (
                             hiddenText


### PR DESCRIPTION
@BillyG83 I changed the color for the hidden text to what we've in the design

<img width="985" alt="Screenshot 2022-05-04 at 09 56 31" src="https://user-images.githubusercontent.com/16763860/166651022-c9b2ea70-395c-493b-a779-0fb4706ffe21.png">
<img width="971" alt="Screenshot 2022-05-04 at 09 56 21" src="https://user-images.githubusercontent.com/16763860/166651037-14d10346-615e-463f-80bf-5a1456c3d7c0.png">
