### PR TITLE
feat/wp5-cra-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "react-blockies": "^1.4.1",
         "react-moralis": "^1.3.5",
         "react-router-dom": "^6.3.0",
-        "styled-components": "^5.3.3"
+        "styled-components": "^5.3.3",
+        "wp5-cra-polyfill": "github:oscario2/wp5-cra-polyfill#91431fa"
     },
     "prettier": {
         "printWidth": 80,


### PR DESCRIPTION
Allow `web3uikit` to work with the latest `create-react-app` out of the box