### PR TITLE
feat(Typography): 550+custom weights support added

### DIFF
--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -69,6 +69,10 @@ const Demo: ComponentStory<typeof Typography> = () => {
                 Caption 12 monospace
             </Typography>
             <br />
+            <Typography variant="caption12" weight="550">
+                Weight 550
+            </Typography>
+            <br />
         </div>
     );
 };

--- a/src/components/Typography/Typography.styles.ts
+++ b/src/components/Typography/Typography.styles.ts
@@ -31,7 +31,9 @@ export const getCSSWeight = (weight: weightType) => {
                 font-weight: 700;
             `;
         default:
-            throw new Error('Not correct font weight');
+            return css`
+                font-weight: ${weight};
+            `;
     }
 };
 

--- a/src/components/Typography/types.ts
+++ b/src/components/Typography/types.ts
@@ -60,7 +60,7 @@ export type variantType =
     | 'caption14'
     | 'caption12';
 
-export type weightType =
+export type TStandardWeight =
     | 'semibold'
     | 'bold'
     | 'regular'
@@ -68,4 +68,9 @@ export type weightType =
     | '400'
     | 'medium'
     | '500'
+    | '550'
     | '700';
+
+export type TCustomWeight = string & {};
+
+export type weightType = TStandardWeight | TCustomWeight;


### PR DESCRIPTION
---
name: 'Typography supports custom font-weights'
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Poor `fontWeight` support in Typography.

### Solution Description

Now the Typography supports weight 550. Also Typography now supports all string type weights , but only standard weights will be displayed in  the hints.

![image](https://user-images.githubusercontent.com/78314301/170209449-bdb20b9b-c403-4ff9-8e54-9cca2e84d9b3.png)

