### PR TITLE
[Input]: fix styling for filled input

### DIFF
--- a/src/components/Input/Input.styles.ts
+++ b/src/components/Input/Input.styles.ts
@@ -71,7 +71,8 @@ const DivWrapperStyled = styled.div<Pick<InputProps, 'state' | 'size'>>`
         }
     }
 
-    &:focus-within {
+    &:focus-within,
+    &.input_filled {
         outline: 2px solid ${color.blue};
 
         label {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -72,11 +72,11 @@ const Input: React.FC<InputProps> = ({
     const hasValidation = () =>
         Boolean(
             validation?.required ||
-            validation?.numberMax ||
-            validation?.numberMin ||
-            validation?.characterMaxLength ||
-            validation?.characterMinLength ||
-            validation?.regExp,
+                validation?.numberMax ||
+                validation?.numberMin ||
+                validation?.characterMaxLength ||
+                validation?.characterMinLength ||
+                validation?.regExp,
         );
 
     const validate = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -88,7 +88,9 @@ const Input: React.FC<InputProps> = ({
             const re = new RegExp(validation?.regExp);
             if (!re.test(event?.target.value)) {
                 setInvalidMessage(
-                    validation?.regExpInvalidMessage || event?.target.validationMessage || errorMessage,
+                    validation?.regExpInvalidMessage ||
+                        event?.target.validationMessage ||
+                        errorMessage,
                 );
                 setCurrentState('error');
                 return;
@@ -105,7 +107,7 @@ const Input: React.FC<InputProps> = ({
         // finally if all pass but the Input is in error state
         if (currentState === 'error') {
             setCurrentState('confirmed');
-            setTimeout(() => setCurrentState('initial'), 3000);
+            setTimeout(() => setCurrentState(undefined), 3000);
         }
     };
 


### PR DESCRIPTION
---
name: 'Input '
about: Input Component filled
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #586 

### Solution Description
![image](https://user-images.githubusercontent.com/35369843/171232850-cc37b79a-f2c3-4668-b779-411d98b0b04a.png)
<!-- Add a description of the solution in this PR. -->
Fix styling for input component
Bug fixed as well in which, after `validation error` of comp is fixed then state changes to `confirmed` and after 3 sec state changes to `initial`. This was changing the label styles as well.  