### PR TITLE
Popover Dropdown inside Dropdown

### DIFF
--- a/src/components/PopoverDropdown/PopoverDropdown.stories.tsx
+++ b/src/components/PopoverDropdown/PopoverDropdown.stories.tsx
@@ -165,3 +165,80 @@ PopoverPositionLeft.args = {
     children: [<button>left position</button>, <button>works too!</button>],
     parent: <button>hover me!</button>,
 };
+
+export const PopoverDropdownInsidePopoverDropdown = Template.bind({});
+PopoverDropdownInsidePopoverDropdown.args = {
+    parent: <button>hover me!</button>,
+    position: 'bottom',
+    children: [
+        <PopoverDropdown
+            id="testing-the-id"
+            parent={
+                <PopoverElement
+                    key="0"
+                    backgroundColor="transparent"
+                    height={50}
+                    icon="testnet"
+                    iconSize={30}
+                    text="Testnet Server"
+                    textColor="#FFFFFF"
+                    textSize={20}
+                    width={260}
+                />
+            }
+            position="left"
+            children={[
+                <PopoverElement
+                    backgroundColor="transparent"
+                    height={50}
+                    icon="network"
+                    iconSize={30}
+                    text="Mainnet Server"
+                    textColor="#FFFFFF"
+                    textSize={20}
+                    width={260}
+                />,
+                <PopoverElement
+                    backgroundColor="transparent"
+                    height={50}
+                    icon="server"
+                    iconSize={30}
+                    text="Local Devchain Server"
+                    textColor="#FFFFFF"
+                    textSize={20}
+                    width={260}
+                />,
+            ]}
+        ></PopoverDropdown>,
+        <PopoverElement
+            backgroundColor="transparent"
+            height={50}
+            icon="testnet"
+            iconSize={30}
+            text="Testnet Server"
+            textColor="#FFFFFF"
+            textSize={20}
+            width={260}
+        />,
+        <PopoverElement
+            backgroundColor="transparent"
+            height={50}
+            icon="network"
+            iconSize={30}
+            text="Mainnet Server"
+            textColor="#FFFFFF"
+            textSize={20}
+            width={260}
+        />,
+        <PopoverElement
+            backgroundColor="transparent"
+            height={50}
+            icon="server"
+            iconSize={30}
+            text="Local Devchain Server"
+            textColor="#FFFFFF"
+            textSize={20}
+            width={260}
+        />,
+    ],
+};

--- a/src/components/PopoverDropdown/PopoverDropdown.styles.tsx
+++ b/src/components/PopoverDropdown/PopoverDropdown.styles.tsx
@@ -16,10 +16,8 @@ const DivStyled = styled.div`
     ${resetCSS};
     position: relative;
 
-    &:hover {
-        ul {
-            display: block;
-        }
+    &:hover > ul {
+        display: block;
     }
 `;
 
@@ -117,7 +115,7 @@ const ListStyled = styled.ul<TStyleProps>`
     min-width: ${(p) => `${p.width}`};
     padding: 8px;
     position: absolute;
-    ${(p) => p.position && setPosition(p.position, p.moveBody)}
+    ${(p) => p.position && setPosition(p.position, p.moveBody)};
 
     &:hover {
         display: block;


### PR DESCRIPTION
---
name: 'Pull request'
about: Popover Dropdown
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #716 

### Solution Description
<img width="1512" alt="Screenshot 2022-07-11 at 11 00 00 PM" src="https://user-images.githubusercontent.com/35369843/178324152-59739c75-d656-4d26-a2a4-0166fb82bd70.png">

<!-- Add a description of the solution in this PR. -->
Instead of the tooltip, we can display a popover dropdown inside a popover dropdown. This is because Tooltip is usually used to display information. But in admin panel we need to switch teams from the popover dropdown. 
Let me know if this has an issue 🙌🏻 