### PR TITLE
fix(NFT): Add contract type prop and manipulate video link

### DIFF
--- a/src/components/NFT/NFT.fetched.tsx
+++ b/src/components/NFT/NFT.fetched.tsx
@@ -11,9 +11,10 @@ const { DivStyled } = NFTStyles;
 const { image } = NFTUtils;
 
 const FetchedNFT: React.FC<{
+    contractType?: string;
     metadata?: TNFTMetadata;
     name?: string;
-}> = ({ metadata, name }) => {
+}> = ({ contractType, metadata, name }) => {
     const [showModal, setShowModal] = useState(false);
     return (
         <DivStyled id="nft">
@@ -26,7 +27,7 @@ const FetchedNFT: React.FC<{
                     <Typography variant="body16">
                         {metadata?.name || name}
                     </Typography>
-                    <Typography variant="caption12">ERC721</Typography>
+                    <Typography variant="caption12">{contractType}</Typography>
                 </div>
             </div>
             <div id="nft-footer">

--- a/src/components/NFT/NFT.tsx
+++ b/src/components/NFT/NFT.tsx
@@ -20,6 +20,7 @@ const { image } = NFTUtils;
 const NFT: React.FC<INFTProps> = ({
     address,
     chain,
+    contractType = 'ERC721',
     name,
     tokenId,
     fetchMetadata,
@@ -51,7 +52,13 @@ const NFT: React.FC<INFTProps> = ({
     }
 
     if (!fetchMetadata) {
-        return <FetchedNFT metadata={metadata} name={name} />;
+        return (
+            <FetchedNFT
+                contractType={contractType}
+                metadata={metadata}
+                name={name}
+            />
+        );
     }
 
     if (!isInitialized && !isInitializing) {
@@ -113,7 +120,7 @@ const NFT: React.FC<INFTProps> = ({
                                 ?.name || name}
                         </Typography>
                         <Typography variant="caption12">
-                            {data.contract_type || 'ERC721'}
+                            {data.contract_type || contractType}
                         </Typography>
                     </div>
                 </div>
@@ -128,16 +135,12 @@ const NFT: React.FC<INFTProps> = ({
                     {showTraits && (
                         <NFTModal
                             attributes={
-                                (
-                                    JSON.parse(
-                                        String(data.metadata),
-                                    ) as TNFTMetadata
-                                )?.traits ||
-                                (
-                                    JSON.parse(
-                                        String(data.metadata),
-                                    ) as TNFTMetadata
-                                )?.attributes
+                                (JSON.parse(
+                                    String(data.metadata),
+                                ) as TNFTMetadata)?.traits ||
+                                (JSON.parse(
+                                    String(data.metadata),
+                                ) as TNFTMetadata)?.attributes
                             }
                             setShowModal={setShowModal}
                         />

--- a/src/components/NFT/NFT.utils.tsx
+++ b/src/components/NFT/NFT.utils.tsx
@@ -20,7 +20,10 @@ const image = (animation?: string, image?: string): React.ReactElement => {
     if (animation?.includes('.mp4') || image?.includes('.mp4')) {
         return (
             <video height={'210px'} width={'100%'} controls autoPlay loop muted>
-                <source src={animation || image} type="video/mp4" />
+                <source
+                    src={manipulateLink(animation || image || '')}
+                    type="video/mp4"
+                />
             </video>
         );
     }

--- a/src/components/NFT/types.ts
+++ b/src/components/NFT/types.ts
@@ -30,6 +30,11 @@ export interface INFTProps {
      * set metadata of NFT
      */
     metadata?: TNFTMetadata | undefined;
+
+    /**
+     * set contract type of NFT
+     */
+    contractType?: string;
 }
 
 /**


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #717 

### Solution Description

<!-- Add a description of the solution in this PR. -->
- removed hardcode value = `ERC721`. Now user can pass the contract type (This is only used when no metadata is fetched by the api).
- fixed issue, video link starting with `ipfs://.....` where not being converted to `https:/...`
