### PR TITLE
onChange function  shouldn't call when component render

### DIFF
--- a/packages/core/src/lib/Upload/Upload.tsx
+++ b/packages/core/src/lib/Upload/Upload.tsx
@@ -14,11 +14,10 @@ const {
 } = styles;
 
 const Upload: React.FC<IUploadProps> = ({ onChange, theme = 'withIcon' }) => {
-    const [fileSelected, setFileSelected] =
-        useState<Blob | undefined | null>(null);
+    const [fileSelected, setFileSelected] = useState<Blob | undefined | null>(
+        null,
+    );
     const inputFile = useRef<HTMLInputElement | null>(null);
-
-    useEffect(() => onChange && onChange(fileSelected), [fileSelected]);
 
     const onClickHandler = () => {
         inputFile.current && inputFile.current.click();
@@ -28,6 +27,7 @@ const Upload: React.FC<IUploadProps> = ({ onChange, theme = 'withIcon' }) => {
         event.preventDefault();
         const file = event.target.files && event.target.files[0];
         setFileSelected(file);
+        onChange && onChange(file);
     };
 
     const onDropHandler = (event: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
---
name: 'fix-upload.tsx-component'
about: previously component triggered onChange function immediately after the render, it should call onChange when something is changed. 
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
