### PR TITLE
added story for static month in DatePicker

### DIFF
--- a/packages/core/src/lib/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/lib/DatePicker/DatePicker.stories.tsx
@@ -1,4 +1,3 @@
-
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import DatePicker from './DatePicker';
 
@@ -33,6 +32,13 @@ export const StaticDate = Template.bind({});
 StaticDate.args = {
     id: 'date-picker',
     value: '1999-12-31',
+};
+
+export const StaticMonth = Template.bind({});
+StaticMonth.args = {
+    id: 'date-picker',
+    type: 'month',
+    value: '2022-08',
 };
 
 export const Validation = Template.bind({});


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description
In Datepicker component in Static Date story inside Forms section, when the type is set to month, it doesn't works instead shows blank line. 
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #836

### Solution Description
when type is set to date then format for default/static value is 'yyyy-mm-dd' 
when the type is set to month static value format should be 'yyyy-mm'.
I created a new story for the case of type-month with 'yyyy-mm' as a static value to let the users know that both static date format is different for type month.
![finalStory](https://user-images.githubusercontent.com/66167434/196048429-c15d44a0-c238-4df1-88ea-6b7590b814f7.png)

<!-- Add a description of the solution in this PR. -->
