### PR TITLE
:hammer: Fix error: "Failed to fetch dynamically imported module in p…

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -39,6 +39,9 @@ module.exports = {
                 fs: require.resolve('rollup-plugin-node-builtins'),
             },
         };
+        config.optimizeDeps = {
+            include: ['msw-storybook-addon'],
+        };
         return config;
     },
     webpackFinal: async (config) => {


### PR DESCRIPTION
---
name: Fix error
about: Related to error: https://github.com/web3ui/web3uikit/issues/989
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Getting `Failed to fetch dynamically imported module: http://localhost:6006/storybook/preview.jsx` when first time run `pnpm storybook`. If restart storybook the error will be resolved automatically.

Steps of reproduce:
1. Download repo git clone git@github.com:web3ui/web3uikit.git
2. Setup node version to v16.16.0
3. Run pnpm install
4. Run pnpm build
5. Run pnpm storybook

Related issue: https://github.com/web3ui/web3uikit/issues/989

### Solution Description

<!-- Add a description of the solution in this PR. -->

According to the storyobok closed issue https://github.com/storybookjs/storybook/issues/18641. The error happens due to package `msw-storybook-addon` is not pre-bundled for the first time of running `pnpm storybook`. Can be resolved by adding it to `optimizeDeps.include` to force it pre-bundled.