### PR TITLE
feat(Select): HTML5 takes disabled options

### DIFF
--- a/.changeset/wild-apes-decide.md
+++ b/.changeset/wild-apes-decide.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/core': patch
+---
+
+HTML5 Select can use disabled options

--- a/packages/core/src/lib/Select/Select.stories.tsx
+++ b/packages/core/src/lib/Select/Select.stories.tsx
@@ -27,6 +27,15 @@ const testOptionsHTML5 = [
     { label: 'Month', id: 'M' },
 ];
 
+const testDisabledOptions = [
+    { label: 'Product 1', id: 'p1' },
+    { label: 'Product 2', id: 'p2' },
+    { label: 'Product 3', id: 'p3' },
+    { label: 'Title 2', id: 'title', disabled: true },
+    { label: 'Product 4', id: 'p4' },
+    { label: 'Product 5', id: 'p5' },
+];
+
 const smallOptionsList = [
     {
         label: 'Discord',
@@ -268,6 +277,15 @@ HTML5SelectValue.args = {
     options: testOptionsHTML5,
     traditionalHTML5: true,
     value: testOptionsHTML5[1]?.label,
+};
+
+export const HTML5SelectDisabled = Template.bind({});
+HTML5SelectDisabled.args = {
+    label: 'Good old HTML5',
+    onChangeTraditional: onTestOptionChange,
+    options: testDisabledOptions,
+    placeholder: 'Title 1',
+    traditionalHTML5: true,
 };
 
 const TemplateBetaSingle: ComponentStory<typeof Select> = (args) => {

--- a/packages/core/src/lib/Select/TraditionalSelect/TraditionalSelect.tsx
+++ b/packages/core/src/lib/Select/TraditionalSelect/TraditionalSelect.tsx
@@ -65,6 +65,7 @@ const TraditionalSelect: React.FC<ISelectProps> = ({
                         id={String(option?.id)}
                         key={option?.id}
                         value={option?.id}
+                        disabled={option.disabled || false}
                     >
                         {option?.prefix}
                         {option?.label}

--- a/packages/core/src/lib/Select/types.ts
+++ b/packages/core/src/lib/Select/types.ts
@@ -193,6 +193,11 @@ export interface OptionProps {
      * id of option. should be unique
      */
     id: string | number;
+
+    /**
+     * an option can be disabled / unselectable
+     */
+    disabled?: boolean;
 }
 
 export interface LabelProps {


### PR DESCRIPTION
HTML5 select can have disabled options that could be used as titles

![Screenshot 2023-02-10 at 17 49 48](https://user-images.githubusercontent.com/13779759/218150287-70fd7f54-8c4b-40c1-98e0-725bf9a43f9b.png)
