### PR TITLE
fix: indicate that any div props can be passed through to ConnectButton

### DIFF
--- a/.changeset/wet-hats-search.md
+++ b/.changeset/wet-hats-search.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/web3': patch
+---
+
+fix(ConnectButton): indicate that any div props can be passed

--- a/packages/web3/src/lib/ConnectButton/types.ts
+++ b/packages/web3/src/lib/ConnectButton/types.ts
@@ -1,4 +1,6 @@
-export interface IConnectButtonProps {
+import type { HTMLAttributes } from 'react';
+
+export interface IConnectButtonProps extends HTMLAttributes<HTMLDivElement> {
     /**
      * an optional chain id of the blockchain that the web3 wallet is connected to
      */


### PR DESCRIPTION
## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

despite taking all extraneous props passed to `ConnectButton`:
![image](https://user-images.githubusercontent.com/15263431/226787480-a1787c95-feae-4cc6-a590-46940eeaf925.png)

and passing them through to the `WrapperStyled` (which is just a styled.div):
![image](https://user-images.githubusercontent.com/15263431/226787538-4f0eb2b1-564e-4762-8e30-5755f7dac0a3.png)

the typings don't actually allow for passing through extraneous properties other than the 3 explicitly defined properties on `IConnectButtonProps`:
![image](https://user-images.githubusercontent.com/15263431/226787637-ac1ca562-699c-4b12-a897-589b34af3fd7.png)



### Solution Description

indicate that `IConnectButtonProps` extends the native HTML attributes for divs, allowing typescript consumers to know they can safely pass through other props such as `className` :3