### PR TITLE
fix(plancard): Added back footer and topLabel does no longer contain …

### DIFF
--- a/.changeset/fast-hornets-peel.md
+++ b/.changeset/fast-hornets-peel.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/core': patch
+---
+
+fix(plancard): Added back footer and topLabel does no longer contain a condition check

--- a/packages/core/src/lib/PlanCard/PlanCard.tsx
+++ b/packages/core/src/lib/PlanCard/PlanCard.tsx
@@ -4,7 +4,7 @@ import { Typography } from '../Typography';
 import { color } from '@web3uikit/styles';
 import { CheckCircleAlt } from '@web3uikit/icons';
 
-const { DivStyled, DivStyledFeatures, DivStyledTopLabel, HrStyled } = styles;
+const { DivStyled, DivStyledFeatures, DivStyledTopLabel, HrStyled, DivStyledCardFooter } = styles;
 
 const PlanCard: React.FC<IPlanCardProps> = ({
     backgroundColor,
@@ -15,7 +15,6 @@ const PlanCard: React.FC<IPlanCardProps> = ({
     horizontalLine = false,
     icon,
     isCurrentPlan,
-    isCurrentBillingPeriod,
     maxWidth,
     description,
     features,
@@ -45,9 +44,7 @@ const PlanCard: React.FC<IPlanCardProps> = ({
             {...props}
         >
             <DivStyledTopLabel>
-                {isCurrentBillingPeriod ? (
-                     <CheckCircleAlt style={{'width': 22, 'height': 22}} fontSize='22px' color={themeColor?.toString()}/>
-                ) : topLabel}
+                {topLabel}
             </DivStyledTopLabel>
             <Typography variant='h2' weight='550' style={{marginBottom: '16px', marginTop: '16px'}}>{title}</Typography>
             <Typography>{subTitle}</Typography>
@@ -86,7 +83,9 @@ const PlanCard: React.FC<IPlanCardProps> = ({
                     </div>
                 ))}
             </DivStyledFeatures>
-
+            <DivStyledCardFooter>
+                {footer}
+            </DivStyledCardFooter>
         </DivStyled>
     );
 };

--- a/packages/core/src/lib/PlanCard/types.ts
+++ b/packages/core/src/lib/PlanCard/types.ts
@@ -16,11 +16,6 @@ export interface IPlanCardProps {
     isCurrentPlan: boolean;
 
     /**
-     * Is the active billing period of the plan, used for differentiating if multiple billing periods exists 
-     */
-    isCurrentBillingPeriod: boolean;
-
-    /**
      * the title component of the Card
      */
     title?: string;


### PR DESCRIPTION
---
Update to Placard
Added back footer and topLabel does no longer contain
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Footer was removed but was still defined as a type in the component. I have now added back footer so it works again.  
TopLabel previously contained a condition to show checkmark if it was the users current billing period of that plan. I have removed this condition and only kept the top label now so there is more flexibility when implementing the placard.  


