### PR TITLE
feat(tag): added lineheight optional on text

### DIFF
--- a/.changeset/twelve-radios-develop.md
+++ b/.changeset/twelve-radios-develop.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/core': patch
+---
+
+feat(tag): Added lineHeight as option to it

--- a/packages/core/src/lib/Tag/Tag.tsx
+++ b/packages/core/src/lib/Tag/Tag.tsx
@@ -17,6 +17,7 @@ const Tag: React.FC<TagProps> = ({
     tone = 'light',
     width = 'fit-content',
     prefixIcon,
+    lineHeight,
     customize,
     ...props
 }: TagProps) => {
@@ -44,7 +45,7 @@ const Tag: React.FC<TagProps> = ({
                 />
             )}
             {prefixIcon && prefixIcon}
-            <strong data-testid="test-tag-text">{text}</strong>
+            <strong style={{ lineHeight: `${lineHeight}px` }} data-testid="test-tag-text">{text}</strong>
             {hasCancel && (
                 <SpanStyled onClick={onCancelClick}>
                     <Cross

--- a/packages/core/src/lib/Tag/types.ts
+++ b/packages/core/src/lib/Tag/types.ts
@@ -73,6 +73,11 @@ export interface TagProps {
     padding?: string;
 
     /**
+     * set line height
+     */
+    lineHeight?: string;
+
+    /**
      * Customize the credentials
      */
     customize?: TCustomize;


### PR DESCRIPTION
---
Tag - lineHeight
added lineheight optional on text
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Needed custom line height than the default 24px as it is today.  Not sure if it's best to apply directly to the component like this or better to add css in the implementation? 