### PR TITLE
Credential: fix icon divider margin

### DIFF
--- a/.changeset/dry-monkeys-scream.md
+++ b/.changeset/dry-monkeys-scream.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/core': major
+---
+
+fix(Credentials) - Incorrect margins for divider div

--- a/packages/core/src/lib/Credentials/Credentials.styles.tsx
+++ b/packages/core/src/lib/Credentials/Credentials.styles.tsx
@@ -47,7 +47,7 @@ const ToolsStyled = styled.div<Pick<ICredentialsProps, 'hasIconTooltip'>>`
 
 const DividerStyled = styled.div`
     position: relative;
-    margin: 0 8px;
+    margin: 8px 8px;
     &:before {
         border-left: 2px solid ${color.navy20};
         content: '';


### PR DESCRIPTION
---
name: 'Fix Credential Component magins'
about: A bug related to the margins of the divider used in the credentials component
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/web3ui/web3uikit/blob/master/CONTRIBUTE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

The divider used to divide icons (hide and copy) in the `Credentials` component is broken. Example: 
![image](https://user-images.githubusercontent.com/60792849/235930155-66e21a7d-7460-42d2-80ec-0de577ebc84c.png)


### Solution Description

Fix the divider margins.
Now:
![image](https://user-images.githubusercontent.com/60792849/235930237-33ac842c-e62c-4c12-8e18-f0753b3ab806.png)

