### PR TITLE
feat(Slider): track bgColor and thumb box shadow prop added

### DIFF
--- a/.changeset/unlucky-years-decide.md
+++ b/.changeset/unlucky-years-decide.md
@@ -1,0 +1,5 @@
+---
+'@web3uikit/core': patch
+---
+
+feat(Slider): custom track bgColor and drop shadow props

--- a/packages/core/src/lib/Slider/Slider.stories.tsx
+++ b/packages/core/src/lib/Slider/Slider.stories.tsx
@@ -51,6 +51,20 @@ Step.args = {
     ],
 };
 
+export const Custom = Template.bind({});
+Custom.args = {
+    max: 151,
+    min: 0,
+    id: 'one',
+    value: 75,
+    disabled: false,
+    labelBgColor: color.blueGray50,
+    bgColor: color.blue40,
+    bgColorTrack: color.fuchsia40,
+    boxShadowOfThumb: '0px 5px 5px rgba(0, 0, 0,  0.2)',
+    handleTooltipLabel: (val) => 'Caught ' + val + ' Pokemon',
+};
+
 export const Disabled = Template.bind({});
 Disabled.args = {
     max: 1000,

--- a/packages/core/src/lib/Slider/Slider.styles.ts
+++ b/packages/core/src/lib/Slider/Slider.styles.ts
@@ -68,7 +68,7 @@ const trackStyles = (props: any) => css`
     background: linear-gradient(
         90deg,
         ${props.$bgColor} ${calculateNewPositionStyleValue(props)},
-        ${color.navy10} ${calculateNewPositionStyleValue(props)}
+        ${props.$bgColorTrack} ${calculateNewPositionStyleValue(props)}
     );
     border-radius: 10px;
     cursor: pointer;
@@ -76,13 +76,13 @@ const trackStyles = (props: any) => css`
     width: 100%;
 `;
 
-const thumbStyles = (bgColor: string) => css`
+const thumbStyles = (bgColor: string, boxShadowOfThumb: string) => css`
     ${resetCSS};
     -webkit-appearance: none;
     background: ${color.white};
     border-radius: 50%;
     border: 0.25rem solid ${colorPercentage(bgColor, 80)};
-    box-shadow: 0 1px 3px ${color.white};
+    box-shadow: ${boxShadowOfThumb || `0 1px 3px ${color.white}`};
     cursor: pointer;
     height: 29px;
     transform: translateY(calc(-50% + 8px));
@@ -91,6 +91,8 @@ const thumbStyles = (bgColor: string) => css`
 
 const InputStyled = styled.input<{
     $bgColor: string;
+    $bgColorTrack: string;
+    $boxShadowOfThumb: string;
     $leftLabel?: string;
     $rightLabel?: string;
 }>`
@@ -110,14 +112,14 @@ const InputStyled = styled.input<{
         ${(props) => trackStyles(props)}
     }
     &::-webkit-slider-thumb {
-        ${(props) => thumbStyles(props.$bgColor)}
+        ${(props) => thumbStyles(props.$bgColor, props.$boxShadowOfThumb)}
     }
     //For mozilla
     &::-moz-range-track {
         ${(props) => trackStyles(props)}
     }
     &::-moz-range-thumb {
-        ${(props) => thumbStyles(props.$bgColor)}
+        ${(props) => thumbStyles(props.$bgColor, props.$boxShadowOfThumb)}
     }
     //For internet explorer
     &::-ms-track {
@@ -134,7 +136,7 @@ const InputStyled = styled.input<{
         ${(props) => trackStyles(props)}
     }
     &::-ms-thumb {
-        ${(props) => thumbStyles(props.$bgColor)}
+        ${(props) => thumbStyles(props.$bgColor, props.$boxShadowOfThumb)}
     }
     &:disabled {
         opacity: 0.6;

--- a/packages/core/src/lib/Slider/Slider.tsx
+++ b/packages/core/src/lib/Slider/Slider.tsx
@@ -13,6 +13,8 @@ const {
 
 const Slider: React.FC<ISliderProps> = ({
     bgColor = color.mint40,
+    bgColorTrack = color.navy10,
+    boxShadowOfThumb = `0 1px 3px ${color.white};`,
     disabled = false,
     handleTooltipLabel,
     id,
@@ -46,6 +48,8 @@ const Slider: React.FC<ISliderProps> = ({
             )}
             <InputStyled
                 $bgColor={bgColor}
+                $bgColorTrack={bgColorTrack}
+                $boxShadowOfThumb={boxShadowOfThumb}
                 data-testid="test-slider-input"
                 id={id}
                 max={max}

--- a/packages/core/src/lib/Slider/types.ts
+++ b/packages/core/src/lib/Slider/types.ts
@@ -1,20 +1,50 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 export interface ISliderProps {
-    /**
-     * pass id for html input component
-     */
-    id: string;
-
     /**
      * background color of slider
      */
     bgColor?: string;
 
     /**
+     * background color of slider background track
+     */
+    bgColorTrack?: string;
+
+    /**
+     * box-shadow to be applied to the thumb
+     */
+    boxShadowOfThumb?: string;
+
+    /**
+     * disables any interaction
+     */
+    disabled?: boolean;
+
+    /**
+     * change label value using current value
+     */
+    handleTooltipLabel?: (val: number) => string | number;
+
+    /**
+     * pass id for html input component
+     */
+    id: string;
+
+    /**
      * label background color
      */
     labelBgColor?: string;
+
+    /**
+     * provide value for left label
+     */
+    leftLabel?: string;
+
+    /**
+     * markers - make sure to pass correct amount based on step size, min and max
+     */
+    markers?: ReactNode[];
 
     /**
      * pass maximum Range for Slider
@@ -27,34 +57,9 @@ export interface ISliderProps {
     min?: number;
 
     /**
-     * value of the slider
-     */
-    value: number;
-
-    /**
      * onChange callback event
      */
     onChange: (value: string) => void;
-
-    /**
-     * disables any interaction
-     */
-    disabled?: boolean;
-
-    /**
-     * set the discrete step size of the element
-     */
-    step?: number;
-
-    /**
-     * provide value for left label
-     */
-    leftLabel?: string;
-
-    /**
-     * provide value for right label
-     */
-    rightLabel?: string;
 
     /**
      * a prefix for the form controller EG: $ or €
@@ -67,12 +72,17 @@ export interface ISliderProps {
     rangeControllerSuffix?: string;
 
     /**
-     * change label value using current value
+     * provide value for right label
      */
-    handleTooltipLabel?: (val: number) => string | number;
+    rightLabel?: string;
 
     /**
-     * markers - make sure to pass correct amount based on step size, min and max
+     * set the discrete step size of the element
      */
-    markers?: ReactNode[];
+    step?: number;
+
+    /**
+     * value of the slider
+     */
+    value: number;
 }


### PR DESCRIPTION
- added track bgColor prop
- added thumb box-shadow props
- added new story
- texted all other stories

Custom:
<img width="462" alt="Screenshot 2023-05-08 at 11 50 31" src="https://user-images.githubusercontent.com/13779759/236807961-533b3101-6084-4ab2-9732-aa8e936a5a2b.png">

Default:
<img width="451" alt="Screenshot 2023-05-08 at 11 54 51" src="https://user-images.githubusercontent.com/13779759/236808000-1768c37f-649f-44e6-bc54-0e531d3ac163.png">

Strepper:
<img width="459" alt="Screenshot 2023-05-08 at 11 54 57" src="https://user-images.githubusercontent.com/13779759/236808025-33c5114b-ef78-4474-97b3-f716fdc7f034.png">

Disabled:
<img width="463" alt="Screenshot 2023-05-08 at 11 55 03" src="https://user-images.githubusercontent.com/13779759/236808068-b3d9b058-f405-481f-b891-ffbe4e0c3cb3.png">
