### PR TITLE
Add prop isChecked to Toggle component

### DIFF
--- a/packages/core/src/lib/Toggle/Toggle.tsx
+++ b/packages/core/src/lib/Toggle/Toggle.tsx
@@ -4,6 +4,7 @@ import ToggleStyles from './Toggle.styles';
 const { LabelStyled } = ToggleStyles;
 
 const Toggle: React.FC<IToggleProps> = ({
+    isChecked,
     customize,
     disabled = false,
     id = 'web3uiKit-toggle',
@@ -39,6 +40,7 @@ const Toggle: React.FC<IToggleProps> = ({
                 {labelOff}
             </span>
             <input
+                checked={isChecked}
                 data-testid="test-toggle-input"
                 disabled={disabled}
                 id={id}

--- a/packages/core/src/lib/Toggle/types.ts
+++ b/packages/core/src/lib/Toggle/types.ts
@@ -6,6 +6,11 @@ export type ValidateCheckbox = {
 
 export interface IToggleProps {
     /**
+     * Whether the toggle is checked or not
+     */
+    isChecked?: boolean;
+
+    /**
      * Customize the element
      */
     customize?: TCustomize;


### PR DESCRIPTION
Added `isChecked` prop to Toggle to define whether the toggle state is `on` or `off`. <br />
It counters the toggle state to reset and make sure it is always set correctly.